### PR TITLE
Fix reversed width x height

### DIFF
--- a/layouts/partials/about.html
+++ b/layouts/partials/about.html
@@ -5,8 +5,8 @@
       <div class="about__profile-picture col-12 col-md-6">
         {{ $img := resources.Get .Site.Data.homepage.about.image.x }}
         {{ $img2x := resources.Get .Site.Data.homepage.about.image._2x }}      
-        {{ $imgWebp := $img.Resize (printf "%dx%d webp" $img.Height $img.Width) }}
-        {{ $img2xWebp := $img.Resize (printf "%dx%d webp" $img2x.Height $img2x.Width) }}
+        {{ $imgWebp := $img.Resize (printf "%dx%d webp" $img.Width $img.Height) }}
+        {{ $img2xWebp := $img.Resize (printf "%dx%d webp" $img2x.Width $img2x.Height) }}
         <picture>
           <source srcset="{{ $imgWebp.RelPermalink }} 1x, {{ $img2xWebp.RelPermalink }} 2x" type="image/webp" />
           <source srcset="{{ $img.RelPermalink }} 1x, {{ $img2x.RelPermalink }} 2x" type="image/webp">


### PR DESCRIPTION
Hi,

Thanks for providing a really solid foundation for setting up a site in Hugo!
However, when I added a picture of myself in the about section I found I was really thin! :) 

The image was resized with reverse dimensions, so here is a small pull request to fix that. See https://gohugo.io/content-management/image-processing/#resize for further documentation, notably:

```
{{/* Resize to a width of 600px and a height of 400px */}}
{{ $image := $image.Resize "600x400" }}
```

Kindly,
Jesper