### PR TITLE
Automate demo repository update on new push to theme

### DIFF
--- a/.github/workflows/update-demo.yml
+++ b/.github/workflows/update-demo.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: 
       - main
-      - update-demo-submodule
 
 jobs:
   update:

--- a/.github/workflows/update-demo.yml
+++ b/.github/workflows/update-demo.yml
@@ -1,3 +1,4 @@
+## taken from https://stackoverflow.com/a/68213855/570087
 name: Update demo site
 on:
   push:
@@ -12,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with: 
-          repository: org/parent_repository
+          repository: zetxek/adritian-demo
           token: ${{ secrets.PRIVATE_TOKEN_GITHUB }}
           submodules: true
 

--- a/.github/workflows/update-demo.yml
+++ b/.github/workflows/update-demo.yml
@@ -1,0 +1,30 @@
+name: Update demo site
+on:
+  push:
+    branches: 
+      - main
+      - update-demo-submodule
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with: 
+          repository: org/parent_repository
+          token: ${{ secrets.PRIVATE_TOKEN_GITHUB }}
+          submodules: true
+
+      - name: Pull & update submodules recursively
+        run: |
+          git submodule update --init --recursive
+          git submodule update --recursive --remote
+
+      - name: Commit
+        run: |
+          git config user.email "actions@github.com"
+          git config user.name "GitHub Actions - update submodules"
+          git add --all
+          git commit -m "Update submodules" || echo "No changes to commit"
+          git push


### PR DESCRIPTION
This action, based on https://stackoverflow.com/a/68213855/570087 by @Mohamed-Shabeer-KP (thanks!) will update the demo site (https://github.com/zetxek/adritian-demo, deployed to https://zetxek.github.io/adritian-demo/) every time that there's a new push to the `main` branch in this repo (the theme one).

It will update the submodules of the parent repo - and deploy automatically. 