### PR TITLE
Fix/experience display

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,12 @@ duration: "2022-2024"
 The beginning of a great career. 
 ```
 
+The experience is displayed in several locations:
+
+1. Homepage, with a limited number of experiences (controlled by the config parameter `homepageExperienceCount` in the file `hugo.toml`). The summary is displayed. 
+2. Experience page, in `/experience`, with a list of all experiences (no limit). The summary is displayed for each item.
+3. Individual experience page, where all details are displayed
+
 ## Troubleshooting
 
 This theme is a version of the one found on my website [adriamoreno.info](https://www.adrianmoreno.info). If you run into trouble, [you can check the code on my website](https://github.com/zetxek/adrianmoreno.info) for reference.

--- a/README.md
+++ b/README.md
@@ -105,6 +105,25 @@ The posts will be markdown files stored in the `content/blog` folder.
 
 It can be used to render job experience of projects. Each experience/project has a duration, job title, company name, location and description/excerpt as well as a longer text. 
 
+The experience is managed through a specific content type (see `content/experience` for an example).
+You should add the following fields to control the content: `title`, `jobTitle`, `company`, `location`, `duration`. The markdown file content will be rendered on the dedicated experience page. 
+
+```
+---
+date: 2007-12-01T00:00:00+01:00
+draft: false
+title: "Job #1"
+jobTitle: "Junior Intern"
+company: "Internet Affairs Inc. "
+location: "Stavanger, Norway"
+duration: "2022-2024"
+
+---
+### Fixing the world, one byte at a time
+
+The beginning of a great career. 
+```
+
 ## Troubleshooting
 
 This theme is a version of the one found on my website [adriamoreno.info](https://www.adrianmoreno.info). If you run into trouble, [you can check the code on my website](https://github.com/zetxek/adrianmoreno.info) for reference.

--- a/data/homepage.yml
+++ b/data/homepage.yml
@@ -93,7 +93,7 @@ experience:
   enable: true
   title: "Experience"
   description: >
-    Over 15+ years of experience working with companies from all over the world. I design & develop digital products to help businesses and improve people's lives.
+    This is where you can highlight a bit over your experience. Years of total experience, specialization, etc.
   button:
     icon: "icon-linkedin-fill"
     btnText: "Linkedin"

--- a/data/homepage.yml
+++ b/data/homepage.yml
@@ -102,6 +102,10 @@ experience:
     icon: "icon-profile-fill"
     btnText: "Download My Resume"
     URL: "#"
+  button3:
+    icon: "icon-arrow-right"
+    btnText: "View All"
+    URL: "/experience"
 
 # Client & Work
 client_and_work:

--- a/data/homepage.yml
+++ b/data/homepage.yml
@@ -103,19 +103,6 @@ experience:
     btnText: "Download My Resume"
     URL: "#"
 
-  items:
-    - title: "Sr. Title"
-      company: "Serious Business, Inc"
-      duration: "Feb 2011 - Sep 2019"
-
-    - title: "Sr. Title"
-      company: "Fancy Company, Inc"
-      duration: "Apr 2010 - Jan 2011"
-
-    - title: "Jr. Title"
-      company: "Company, Inc"
-      duration: "Jun 2009 - Mar 2010"
-
 # Client & Work
 client_and_work:
   title: "Clients & Works"

--- a/exampleSite/data/homepage.yml
+++ b/exampleSite/data/homepage.yml
@@ -89,7 +89,7 @@ experience:
   enable: true
   title: "Experience"
   description: >
-    Over 15+ years of experience working with companies from all over the world. I design & develop digital products to help businesses and improve people's lives.
+   This is where you can highlight a bit over your experience. Years of total experience, specialization, etc.
   button:
     icon: "icon-linkedin-fill"
     btnText: "Linkedin"
@@ -98,19 +98,6 @@ experience:
     icon: "icon-profile-fill"
     btnText: "Download My Resume"
     URL: "#"
-
-  items:
-    - title: "Sr. Title"
-      company: "Serious Business, Inc"
-      duration: "Feb 2011 - Sep 2019"
-
-    - title: "Sr. Title"
-      company: "Fancy Company, Inc"
-      duration: "Apr 2010 - Jan 2011"
-
-    - title: "Jr. Title"
-      company: "Company, Inc"
-      duration: "Jun 2009 - Mar 2010"
 
 # Client & Work
 client_and_work:

--- a/layouts/partials/experience.html
+++ b/layouts/partials/experience.html
@@ -11,7 +11,7 @@
                 {{ if not .IsHome }}
                 {{ $totalCount = len $xp }}
                 {{ end }}
-                {{ range first 6 $xp }}
+                {{ range first $totalCount $xp }}
                 <div class="experience">
                     <a href="{{.Permalink}}">
                         {{/* The context, ".", is now each one of the pages as it goes


### PR DESCRIPTION
Fixing issue reported in #49 by @marctalcott.

1. homepage
<img width="1298" alt="SCR-20240807-nlce" src="https://github.com/user-attachments/assets/cd579409-c9a8-4be6-b1dd-86442de1ff80">

2. experience list page
<img width="1257" alt="SCR-20240807-nldr" src="https://github.com/user-attachments/assets/01484f96-bc05-443f-ae96-4b79b562dcd2">

3. experience individual page

<img width="1283" alt="SCR-20240807-nlep" src="https://github.com/user-attachments/assets/5486d72c-a649-49e0-b707-0567c0a2df18">

Updated the `README` as well to reflect the usage.
