### PR TITLE
Adds support for Vercel speed insights

### DIFF
--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -72,6 +72,9 @@ theme = "adritian-free-hugo-theme"
 
   homepageExperienceCount = 6
 
+  # controls vercel page insights - disabled by default
+  vercelPageInsights = false
+  
   [params.google_analytics]
       code = "UA-XXXXX-Y"
       enabled = false

--- a/layouts/partials/base-foot.html
+++ b/layouts/partials/base-foot.html
@@ -15,4 +15,12 @@
 <script defer src='{{ "js/library/smooth-scroll.polyfills.min.js" | absURL }}'></script>
 <script defer src='{{ "js/sticky-header.js" | absURL }}'></script>
 <script defer src='{{ "js/smooth-scroll-init.js" | absURL }}'></script>
+<!-- vercel insights -->
+{{ $vercelPageInsights := .Site.Params.vercelPageInsights }}
+{{ if $vercelPageInsights }}
 <script defer src='{{ "js/library/bootstrap.min.js" | absURL }}'></script>
+<script>
+  window.si = window.si || function () { (window.siq = window.siq || []).push(arguments); };
+</script>
+<script defer src="/_vercel/speed-insights/script.js"></script>
+{{ end }}


### PR DESCRIPTION
Adding support for Vercel Page Insights: https://vercel.com/docs/speed-insights/quickstart
By using the html/vanilla JS version.

Configured via a new parameter ("false" by default)