### PR TITLE
Fix for experience order

### DIFF
--- a/layouts/partials/experience.html
+++ b/layouts/partials/experience.html
@@ -15,7 +15,7 @@
                 {{ if not .IsHome }}
                 {{ $totalCount = len $xp }}
                 {{ end }}
-                {{ range first $totalCount (sort $xp "Date" "asc") }}
+                {{ range first $totalCount (sort $xp "Date" "desc") }}
                 <div class="experience">
                     <a href="{{.Permalink}}">
                         {{/* The context, ".", is now each one of the pages as it goes


### PR DESCRIPTION
Consistently sorting based on the `date` for all `experience` contents.
Fixes https://github.com/zetxek/adritian-free-hugo-theme/issues/80.