### PR TITLE
Fix Dark Mode Lists Color

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -10857,6 +10857,12 @@ aside.content-browser{
     .h1, .h2, .h3, .h4, .h5, .h6, h1, h2, h3, h4, h5, h6{
         color: #fff;
     }
+    .section li{
+        color: #a6a6a6
+    }
+    .section li::before{
+        background-color: #a6a6a6
+    }
     .display-1{
         color: #fff;
     }

--- a/exampleSite/content/blog/sample-2.md
+++ b/exampleSite/content/blog/sample-2.md
@@ -6,7 +6,15 @@ type = 'blog'
 +++
 
 Sample blog content. Like a lorem ipsum but saying something more interesting.
-
+- This is an unordered list sample 1
+- This is an unordered list sample 2
+    - This is an unordered indented list sample 1
+    - This is an unordered indented list sample 2
+1. This is an ordered list sample 1
+2. This is an ordered list sample 2
+    1. This is an ordered indented list sample 1
+    2. This is an ordered indented list sample 2
+    
 Welcome to the world of "Content Ipsum," the fresh alternative to the classic lorem ipsum. It's the perfect blend for designers and writers who crave a dash of creativity and meaning in their placeholder text. Imagine a text that not only fills the space but also sparks the imagination, a text that weaves tales of innovation, inspiration, and the endless possibilities that creativity brings.
 
 In the realm of "Content Ipsum," every paragraph is a journey through the wonders of the human mind, a celebration of the achievements that have shaped our world, and a look into the future that awaits us. From the depths of the ocean to the farthest reaches of the universe, "Content Ipsum" takes you on an adventure that captivates and informs.


### PR DESCRIPTION
In dark mode, lists would display with dark text against a dark background:
![theme issues](https://github.com/user-attachments/assets/d2373098-a6e4-4af8-ac17-65b5d1c7587d)

This change is to resolve that issue in dark mode:
![fixed theme issues](https://github.com/user-attachments/assets/8dda9492-e169-4621-a568-aead8702d186)

I have added that sample of the fix into the sample blogs for reference. 