### PR TITLE
Setup crossorigin policy

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -28,7 +28,7 @@
   {{ $scss := resources.Get .URL }}
   
   {{ $style := $scss | css.Sass | resources.Fingerprint }}
-  <link rel="stylesheet" href="{{ $style.Permalink }}" integrity="{{ $style.Data.Integrity }}">
+  <link rel="stylesheet" href="{{ $style.Permalink }}" integrity="{{ $style.Data.Integrity }}" crossorigin="anonymous">
 
 {{ end }}
 
@@ -49,6 +49,7 @@
   onload="this.onload=null;this.rel='stylesheet'"
   {{ if hugo.IsProduction -}} 
     integrity="{{ $css.Data.Integrity }}"
+    crossorigin="anonymous"
   {{- end }}
 />
 <noscript>
@@ -57,6 +58,7 @@
     href="{{ $css.RelPermalink }}"
     {{ if hugo.IsProduction -}} 
     integrity="{{ $css.Data.Integrity }}"
+    crossorigin="anonymous"
     {{- end }}
   />
 </noscript>


### PR DESCRIPTION
Error:

```
Subresource Integrity: The resource 'https://adritian-demo-lz321xqpk-adrianmoreno.vercel.app/css/menu.6e233ea8020133c8fdf840fc9876a529cacbe674c7d8193cc12963d7eb29f253.css' has an integrity attribute, but the resource requires the request to be CORS enabled to check the integrity, and it is not. The resource has been blocked because the integrity cannot be enforced.
```

Which causes CSS to partially not load in the demo site (https://adritian-demo.vercel.app/).