### PR TITLE
Add ids to all homepage sections + fix typo

### DIFF
--- a/layouts/partials/about.html
+++ b/layouts/partials/about.html
@@ -1,5 +1,5 @@
 {{ if .Site.Data.homepage.about.enable }}
-<section class="section rad-animation-group pb-0" id="about">
+<section id="about" class="section rad-animation-group pb-0" >
   <div class="container rad-fade-down">
     <div class="row d-flex flex-column-reverse flex-md-row">
       <div class="about__profile-picture col-12 col-md-6">

--- a/layouts/partials/education.html
+++ b/layouts/partials/education.html
@@ -1,5 +1,5 @@
 {{ if .Site.Data.homepage.education.enable }}
-<section class="section section--border-bottom rad-animation-group">
+<section id="education" class="section section--border-bottom rad-animation-group">
     <div class="container">
         <div class="row rad-fade-down">
             <div class="col-12">

--- a/layouts/partials/newsletter.html
+++ b/layouts/partials/newsletter.html
@@ -1,5 +1,5 @@
 {{ if .Site.Data.homepage.newsletter.enable }}
-<section class="section section--cta">
+<section id="newsletter" class="section section--cta">
 <div class="container">
   <div class="row">
     <div class="col-12 text-center">

--- a/layouts/partials/showcase.html
+++ b/layouts/partials/showcase.html
@@ -1,5 +1,5 @@
 {{ if .Site.Data.homepage.showcase.enable }}
-<section class="rad-showcase rad-showcase--index rad-animation-group rad-fade-down">
+<section id="showcase" class="rad-showcase rad-showcase--index rad-animation-group rad-fade-down">
   <div class="container">
     <div class="row flex-column-reverse flex-md-row rad-fade-down rad-waiting rad-animate">
       <div class="col-12 col-sm-12 col-md-6 col-lg-6 col-xl-6">

--- a/layouts/partials/testimonial.html
+++ b/layouts/partials/testimonial.html
@@ -1,12 +1,12 @@
 {{ if .Site.Data.homepage.testimonial.enable }}
-<section class="section rad-animation-group section--border-bottom">
+<section id="testimonial" class="section rad-animation-group section--border-bottom">
     <div class="container">
         <h2 class="rad-fade-down">{{ i18n "testimonials_title" }}</h2>
         <div class="row row--padded mb-0 rad-fade-down">
             
             {{ $baseLangSite := .Sites.Default }}
             {{ $testimonials := (where .Site.RegularPages.ByDate "Type" "testimonial") }}
-            {{ $testimonials = $testimonials | lang.Merge (where $baseLangSite.RegularPages.ByDate "Type" "testimonia") }}   
+            {{ $testimonials = $testimonials | lang.Merge (where $baseLangSite.RegularPages.ByDate "Type" "testimonial") }}
             {{ range $testimonials }} 
 
             <div class="col-12 col-md-4 mb-5 mb-md-0 testimonial">


### PR DESCRIPTION
Adds ids to all homepage partials sections + fix typo in testimonial.html

I believe it would be beneficial to append a unique ID to every `<section>` element (that renders on homepage), enabling the creation of anchors from the primary navigation if necessary. This approach eliminates the need for overriding the `layouts/partials/testimonial.html` template in my particular case.

What do you think @zetxek?

Also I found a typo, fixed.

~~PD: the github-actions changed the README.md, but only affects the sort order of my contrib, no problem :P~~ Ok i don't see the diff of the README.md after PR creation :thinking: 