### PR TITLE
Footer sticks to bottom of the page on experience & blog views

### DIFF
--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -9,7 +9,7 @@
 <body>
   {{ partial "header.html" . }}
 
-  <main class="blog"> 
+  <main class="blog flex-grow-1"> 
     <section class="container section">
       <h1 class="rad-fade-down rad-waiting rad-animate">{{ .Title }}</h1>
       <div class="posts-list container">

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -10,7 +10,7 @@
 
     <section
       id="blog-single"
-      class="section section--border-bottom rad-animation-group"
+      class="section section--border-bottom rad-animation-group flex-grow-1"
     >
       <div class="container">
         <h1><a href="{{ .RelPermalink }}">{{ .Title }}</a></h1>

--- a/layouts/experience/single.html
+++ b/layouts/experience/single.html
@@ -10,7 +10,7 @@
 
     <section
       id="experience"
-      class="section section--border-bottom rad-animation-group"
+      class="section section--border-bottom rad-animation-group flex-grow-1"
     >
       <div class="container">
         <div class="row flex-column-reverse flex-md-row rad-fade-down">

--- a/layouts/partials/experience.html
+++ b/layouts/partials/experience.html
@@ -1,5 +1,5 @@
 {{ if .Site.Data.homepage.experience.enable }}
-<section id="experience" class="section-experience section section--border-bottom rad-animation-group">
+<section id="experience" class="section-experience section section--border-bottom rad-animation-group flex-grow-1">
     <div class="container">
         <div class="row flex-column-reverse flex-md-row rad-fade-down">
             <div class="col-12 cold-md-12 col-sm-6 mt-5 mt-sm-0">


### PR DESCRIPTION
## Current state
The footer will not stay on the bottom of the page if there is not enough content on **Experience** and **Blog** views:

![image](https://github.com/user-attachments/assets/c18a4095-36c5-48b8-a9cd-4fec18d95c26)

## Solution 1

This commit uses bootstrap `flex-grow-1` utility to expand the main content pushing the footer all the way to the bottom of the page:

![image](https://github.com/user-attachments/assets/91c01629-a8b4-430a-b57e-9c25ba0572fa)

The images show only the example of the problem but the **fix is for all of the views**.

## Solution 2

Another possible solution is to resolve this issues in css/scss files, removing the need for bootstrap, like so:

`
#experience,
#blog-single,
.blog {
  -webkit-box-flex: 1;
  flex: 1;
}
`