### PR TITLE
Improved readability for "date" in hover/active mode

### DIFF
--- a/assets/scss/_raditian.scss
+++ b/assets/scss/_raditian.scss
@@ -1406,6 +1406,15 @@ body.home div.experience{
     color: white !important;
 }
 
+.experience.selected a > .experience__date,
+.experience:hover a > .experience__date,
+.experience:active a > .experience__date,
+.experience a:hover > .experience__date,
+.experience a:active > .experience__date{
+    color: white !important;
+}
+
+
 .all-experience-container{
     margin-top: 50px;
 }


### PR DESCRIPTION
Set the "experience__date" in white when active - works better with the green background.

Before

<img width="1512" alt="SCR-20250101-ruja" src="https://github.com/user-attachments/assets/a4898d17-fa57-43c0-8914-5cfbb4df42fc" />
<img width="1512" alt="SCR-20250101-ruhp-2" src="https://github.com/user-attachments/assets/dd3d87fb-9c55-41ca-b465-c7635c7ec91e" />

After (now)

<img width="1512" alt="SCR-20250101-ruff" src="https://github.com/user-attachments/assets/52f7e700-7488-4c7e-8518-cb2c3472d37f" />
<img width="1512" alt="SCR-20250101-rudw-2" src="https://github.com/user-attachments/assets/2954b22c-5841-44e2-94e6-1a15577e5df0" />
