### PR TITLE
Added "skip to content" logic

### DIFF
--- a/assets/scss/adritian.scss
+++ b/assets/scss/adritian.scss
@@ -177,6 +177,24 @@ footer_links .nav-item .nav-link::after {
     color: white;
     background-color: white !important;
 }
+
+/* skip to content */
+.skip-to-content-link {
+    position: absolute;
+    left: -9999px;
+    z-index: 999;
+    padding: 1em;
+    background-color: white;
+    color: black;
+    opacity: 0;
+  }
+  
+  .skip-to-content-link:focus {
+    left: 50%;
+    transform: translateX(-50%);
+    opacity: 1;
+  }
+  
 /* dark mode */
 /** Media-query based color switching **/
 // $color-mode-type: media-query;

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -17,6 +17,10 @@
 - id: "logo_text2"
   translation: "Demo"
 
+## General
+- id: "skipToMainContent"
+  translation: "Skip to main content"
+
 ## Footer
 - id: "footer_notice"
   translation: "© Adritian. Free Hugo theme by Adrián Moreno Peña."

--- a/i18n/es.yaml
+++ b/i18n/es.yaml
@@ -5,6 +5,11 @@
 - id: "logo_text2"
   translation: "Nombre"
 
+
+## General
+- id: "skipToMainContent"
+  translation: "Saltar al contenido principal"
+
 ## Footer
 - id: "footer_notice"
   translation: "© Adritian. Tema gratuito de Hugo por Adrián Moreno Peña."

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -5,6 +5,10 @@
 - id: "logo_text2"
   translation: "Nom"
 
+## General
+- id: "skipToMainContent"
+  translation: "Aller au contenu principal"
+
 ## Footer
 - id: "footer_notice"
   translation: "© Adritian. Thème gratuit Hugo par Adrián Moreno Peña."

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -10,7 +10,7 @@
   {{ partial "header.html" . }}
 
   <main class="list"> 
-    <section class="container section">
+    <section id="main-content" class="container section">
       <h1>{{ .Title }}</h1>
       <ul>
         <!-- Renders the li.html content view for each content/posts/*.md -->

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -9,7 +9,7 @@
 <body>
   {{ partial "header.html" . }}
 
-  <main class="blog flex-grow-1"> 
+  <main id="main-content" class="blog flex-grow-1"> 
     <section class="container section">
       <h1 class="rad-fade-down rad-waiting rad-animate">{{ .Title }}</h1>
       <div class="posts-list container">

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -12,7 +12,7 @@
       id="blog-single"
       class="section section--border-bottom rad-animation-group flex-grow-1"
     >
-      <div class="container">
+      <div id="main-content" class="container">
         <h1><a href="{{ .RelPermalink }}">{{ .Title }}</a></h1>
 
         <aside id="meta" class="light-border-bottom">

--- a/layouts/experience/single.html
+++ b/layouts/experience/single.html
@@ -12,7 +12,7 @@
       id="experience"
       class="section section--border-bottom rad-animation-group flex-grow-1"
     >
-      <div class="container">
+      <div id="main-content" class="container">
         <div class="row flex-column-reverse flex-md-row rad-fade-down">
           <div class="col-12 col-md-5 mt-5 mt-sm-0">
 

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -11,6 +11,9 @@
 ></noscript>
 <!-- End Google Tag Manager (noscript) -->
 {{ end }}
+
+{{ partial "skip-to-content.html" }}
+
 <header class="header fixed-top rad-animation-group" id="header">
   <div class="container rad-fade-in">
     <nav class="navbar bd-navbar navbar-expand-lg navbar-light p-0">
@@ -51,4 +54,6 @@
   </div>
 </header>
 
-{{ if not .IsHome }} {{ partial "breadcrumb.html" . }} {{ end }}
+{{- if not .IsHome }} 
+  {{ partial "breadcrumb.html" . }} 
+{{- end }}

--- a/layouts/partials/showcase.html
+++ b/layouts/partials/showcase.html
@@ -1,6 +1,6 @@
 {{ if .Site.Data.homepage.showcase.enable }}
 <section id="showcase" class="rad-showcase rad-showcase--index rad-animation-group rad-fade-down">
-  <div class="container">
+  <div id="main-content" class="container">
     <div class="row flex-column-reverse flex-md-row rad-fade-down rad-waiting rad-animate">
       <div class="col-12 col-sm-12 col-md-6 col-lg-6 col-xl-6">
         <h1 class="display-1">

--- a/layouts/partials/skip-to-content.html
+++ b/layouts/partials/skip-to-content.html
@@ -1,0 +1,5 @@
+<a href="#main-content" 
+    class="skip-to-content-link"
+    aria-label='{{ i18n "skipToMainContent" }}'>
+  {{ i18n "skipToMainContent" }}
+</a>

--- a/tests/e2e/basic.spec.ts
+++ b/tests/e2e/basic.spec.ts
@@ -57,4 +57,30 @@ test.describe('Theme basic functionality', () => {
     await page.goto(BASE_URL);
     await expect(page.locator('.footer_links')).toBeVisible();
   });
+
+  test('skip to content link works', async ({ page }) => {
+    // Navigate to a content page
+    await page.goto(`${BASE_URL}/blog`);
+    
+    // The skip link should be initially hidden but in the DOM
+    const skipLink = page.locator('.skip-to-content-link');
+    await expect(skipLink).toBeAttached();
+    
+    // Focus the skip link (simulates tabbing to it)
+    await skipLink.focus();
+    
+    // Now it should be visible
+    await expect(skipLink).toBeVisible();
+    
+    // Click the skip link
+    await skipLink.click();
+    
+    // Verify we jumped to the main content
+    // Check URL hash
+    await expect(page).toHaveURL(/#main-content$/);
+    
+    // Verify focus is moved to main content
+    const mainContent = page.locator('#main-content');
+    await expect(mainContent).toBeFocused();
+  });
 });

--- a/tests/e2e/basic.spec.ts
+++ b/tests/e2e/basic.spec.ts
@@ -72,8 +72,8 @@ test.describe('Theme basic functionality', () => {
     // Now it should be visible
     await expect(skipLink).toBeVisible();
     
-    // Click the skip link
-    await skipLink.click();
+    // Press Enter key on the skip link
+    await skipLink.press('Enter');
     
     // Verify we jumped to the main content
     // Check URL hash


### PR DESCRIPTION
Fixes (or more like replaces) #29.
The content overviews should come from the semantic structure of the HTML.
This PR adds a "skip to content" link for navigation with keyboard. It works in dark and light mode.

This implementation:

1. Creates an accessible link that's only visible when tabbing through the page
2. Positions the link off-screen by default
3. Makes it visible when focused via keyboard navigation
4. Uses high contrast colors for visibility
5. Links to the main content area using #main-content

When users tab backwards (Shift+Tab), the skip link will become visible and allow them to jump directly to the main content, bypassing navigation menus.

https://github.com/user-attachments/assets/2e4b8dd3-4e41-4b55-9521-0c6efa40b2eb

