### PR TITLE
Add/improve tags (taxonomies) support

### DIFF
--- a/assets/scss/_raditian.scss
+++ b/assets/scss/_raditian.scss
@@ -1458,6 +1458,14 @@ article.post.summary h2{
     margin-bottom: 20px;
 }
 
+ul.tags {
+    display: inline-flex;
+    gap: 0.5rem;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
 #blog-single #meta{
     margin-bottom: 20px;
 }

--- a/assets/scss/_raditian.scss
+++ b/assets/scss/_raditian.scss
@@ -1464,7 +1464,29 @@ ul.tags {
     margin: 0;
     padding: 0;
     list-style: none;
-  }
+
+    li {
+      position: relative;
+      display: inline-block;
+      padding: 0.4em 1.2em 0.4em 1.6em;
+      background-color: #f5f5f5;
+      color: #333;
+      font-size: 0.9rem;
+      border-radius: 0.25rem;
+
+      &::before {
+        content: "";
+        position: absolute;
+        left: 0.4em;
+        top: 50%;
+        transform: translateY(-50%) rotate(45deg);
+        width: 0.6em;
+        height: 0.6em;
+        background-color: #f5f5f5;
+        border-radius: 2px;
+      }
+    }
+}
 
 #blog-single #meta{
     margin-bottom: 20px;

--- a/exampleSite/content/blog/sample.md
+++ b/exampleSite/content/blog/sample.md
@@ -10,8 +10,142 @@ tags:
 
 Sample blog content. Like a lorem ipsum but saying something more interesting.
 
-Welcome to the world of "Content Ipsum," the fresh alternative to the classic lorem ipsum. It's the perfect blend for designers and writers who crave a dash of creativity and meaning in their placeholder text. Imagine a text that not only fills the space but also sparks the imagination, a text that weaves tales of innovation, inspiration, and the endless possibilities that creativity brings.
+We will show some content that is supported:
 
-In the realm of "Content Ipsum," every paragraph is a journey through the wonders of the human mind, a celebration of the achievements that have shaped our world, and a look into the future that awaits us. From the depths of the ocean to the farthest reaches of the universe, "Content Ipsum" takes you on an adventure that captivates and informs.
+## Basic Syntax
 
-So, the next time you're crafting a design or drafting a document, let "Content Ipsum" infuse your work with the spirit of discovery and the joy of creation. It's more than just text; it's a narrative that connects, engages, and inspires. Welcome to the evolution of placeholder text – where every word is a story waiting to be told.
+### Headings
+
+```
+# Heading 1
+## Heading 2
+### Heading 3
+#### Heading 4
+##### Heading 5
+###### Heading 6
+```
+
+## Heading 2
+### Heading 3
+#### Heading 4
+##### Heading 5
+###### Heading 6
+
+### Emphasis
+
+```text
+*This text will be italic*
+_This will also be italic_
+
+**This text will be bold**
+__This will also be bold__
+
+_You **can** combine them_
+```
+
+*This text will be italic*
+
+_This will also be italic_
+
+**This text will be bold**
+
+__This will also be bold__
+
+_You **can** combine them_
+
+### Lists
+
+#### Unordered
+
+```
+* Item 1
+* Item 2
+  * Item 2a
+  * Item 2b
+```
+
+* Item 1
+* Item 2
+  * Item 2a
+  * Item 2b
+
+#### Ordered
+
+```
+1. Item 1
+2. Item 2
+3. Item 3
+   1. Item 3a
+   2. Item 3b
+```
+
+### Images
+
+```markdown
+![GitHub Logo](https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png)
+```
+
+![GitHub Logo](https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png)
+
+### Links
+
+```markdown
+[Hugo](https://gohugo.io)
+```
+
+[Hugo](https://gohugo.io)
+
+### Blockquotes
+
+```markdown
+As Newton said:
+
+> If I have seen further it is by standing on the shoulders of Giants.
+```
+
+> If I have seen further it is by standing on the shoulders of Giants.
+
+### Inline Code
+
+```markdown
+Inline `code` has `back-ticks around` it.
+```
+
+Inline `code` has `back-ticks around` it.
+
+### Code Blocks
+
+#### Syntax Highlighting
+
+````markdown
+```go
+func main() {
+    fmt.Println("Hello World")
+}
+```
+````
+
+```go
+func main() {
+    fmt.Println("Hello World")
+}
+```
+
+### Tables
+
+```markdown
+| Syntax    | Description |
+| --------- | ----------- |
+| Header    | Title       |
+| Paragraph | Text        |
+```
+
+| Syntax    | Description |
+| --------- | ----------- |
+| Header    | Title       |
+| Paragraph | Text        |
+
+## References
+
+- [Markdown Syntax](https://www.markdownguide.org/basic-syntax/)
+- [Hugo Markdown](https://gohugo.io/content-management/formats/#markdown)

--- a/exampleSite/content/blog/sample.md
+++ b/exampleSite/content/blog/sample.md
@@ -1,9 +1,12 @@
-+++
-title = 'Sample blog content 1'
-date = 2024-06-21T14:38:33+02:00
-draft = false
-type = 'blog'
-+++
+---
+title: 'Sample blog content 1'
+date: 2024-06-21T14:38:33+02:00
+draft: false
+type: 'blog'
+tags: 
+  - sample
+  - lorem-ipsum
+---
 
 Sample blog content. Like a lorem ipsum but saying something more interesting.
 

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -9,7 +9,7 @@
 <body>
   {{ partial "header.html" . }}
   <!-- list type: {{ .Kind }} -->
-  <main class="list"> 
+  <main class="list flex-grow-1"> 
     <section id="main-content" class="container section list-{{ .Kind }}">
       <h1>{{ .Title }}</h1>
       {{ if eq .Kind "taxonomy" }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -8,16 +8,25 @@
 
 <body>
   {{ partial "header.html" . }}
-
+  <!-- list type: {{ .Kind }} -->
   <main class="list"> 
-    <section id="main-content" class="container section">
+    <section id="main-content" class="container section list-{{ .Kind }}">
       <h1>{{ .Title }}</h1>
-      <ul>
-        <!-- Renders the li.html content view for each content/posts/*.md -->
-        {{ range .Pages }}
-          {{ .Render "li" }}
-        {{ end }}
-      </ul>
+      {{ if eq .Kind "taxonomy" }}
+        <ul>
+          {{ range .Data.Terms.ByCount }}
+            <li>
+              <a href="{{ .Page.RelPermalink }}">{{ .Page.Title }}</a> ({{ .Count }})
+            </li>
+          {{ end }}
+        </ul>
+      {{ else }}
+        <ul>
+          {{ range .Pages }}
+            {{ .Render "li" }}
+          {{ end }}
+        </ul>
+      {{ end }}
     </section>
   </main>
 

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -13,9 +13,9 @@
     <section id="main-content" class="container section list-{{ .Kind }}">
       <h1>{{ .Title }}</h1>
       {{ if eq .Kind "taxonomy" }}
-        <ul>
+        <ul class="list list-{{ .Kind }}">
           {{ range .Data.Terms.ByCount }}
-            <li>
+            <li class="item item-{{ .Page.Kind }}">
               <a href="{{ .Page.RelPermalink }}">{{ .Page.Title }}</a> ({{ .Count }})
             </li>
           {{ end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -21,7 +21,7 @@
         </ul>
       {{ end }}
       {{ with .GetTerms "tags" }}
-        <ul id="tags">
+        <ul class="tags">
           {{ range . }}
             <li><a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a></li>
           {{ end }}

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -30,7 +30,7 @@
               {{ end }}
             </ul>
             {{ end }} {{ with .GetTerms "tags" }}
-            <ul id="tags">
+            <ul class="tags">
               {{ range . }}
               <li><a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a></li>
               {{ end }}

--- a/layouts/blog/summary.html
+++ b/layouts/blog/summary.html
@@ -5,17 +5,17 @@
       <div>
         <section>
           {{ i18n "published_on" }} 
-          <h4 id="date">{{ .Date.Format "Mon Jan 2, 2006" }}</h4> · 
-          <h4 id="wordcount">{{ .WordCount }} Words</h4>
+          <h4 class="date">{{ .Date.Format "Mon Jan 2, 2006" }}</h4> · 
+          <h4 class="wordcount">{{ .WordCount }} Words</h4>
         </section>
         {{ with .GetTerms "topics" }}
-        <ul id="topics">
+        <ul class="topics">
           {{ range . }}
           <li><a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a></li>
           {{ end }}
         </ul>
         {{ end }} {{ with .GetTerms "tags" }}
-        <ul id="tags">
+        <ul class="tags">
           {{ range . }}
           <li><a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a></li>
           {{ end }}

--- a/layouts/partials/breadcrumb.html
+++ b/layouts/partials/breadcrumb.html
@@ -1,26 +1,41 @@
 <section id="breadcrumb-bar" class="breadcrumb-bar container">
-        <ul class="breadcrumbs">
-            <li class="breadcrum-item"><span><a href="{{ relURL "" }}">Home</a></span></li>
-            {{- $.Scratch.Set "url" "" -}}
-            {{- range (split .RelPermalink "/") -}}
-                {{- if (gt (len .) 0) -}}    
-                    {{- $.Scratch.Set "isPage" "false" -}}
-                    {{- $.Scratch.Add "url" (print "/" . ) -}}
-                    {{- if $.Site.GetPage (print . ".md") -}}
-                        {{- with $.Site.GetPage (print . ".md") -}}
-                            {{- if .IsPage -}}
-                                {{- $.Scratch.Set "isPage" "true" -}}
-                            {{- end -}}
-                        {{- end -}}
+    <ul class="breadcrumbs">
+        <li class="breadcrum-item"><span><a href="{{ relURL "" }}">Home</a></span></li>
+        {{- $.Scratch.Set "url" "" -}}
+        {{- $taxonomy := .Data.Plural -}}
+        {{- range $index, $element := (split (trim .RelPermalink "/") "/") -}}
+            {{- $.Scratch.Add "url" (print "/" . ) -}}
+            {{- if eq $index 0 -}}
+                {{- if eq . "tags" -}}
+                    <li class="breadcrum-item"><span><a href="{{ $.Scratch.Get `url` }}">Tags</a></span></li>
+                {{- else if eq . "categories" -}}
+                    <li class="breadcrum-item"><span><a href="{{ $.Scratch.Get `url` }}">Categories</a></span></li>
+                {{- else -}}
+                    {{- $section := $.Site.GetPage "section" . -}}
+                    {{- if $section -}}
+                        <li class="breadcrum-item"><span><a href="{{ $.Scratch.Get `url` }}">{{ $section.Title }}</a></span></li>
+                    {{- else -}}
+                        <li class="breadcrum-item"><span><a href="{{ $.Scratch.Get `url` }}">{{ humanize . }}</a></span></li>
                     {{- end -}}
-                    {{- if eq ($.Scratch.Get "isPage") "true" -}}
-                        {{- with $.Site.GetPage (print . ".md") -}}
-                            <li class="breadcrum-item current">{{ .Title }}</li>
+                {{- end -}}
+            {{- else -}}
+                {{- if eq $taxonomy "tags" -}}
+                    <li class="breadcrum-item current">{{ humanize . }}</li>
+                {{- else if eq $taxonomy "categories" -}}
+                    <li class="breadcrum-item current">{{ humanize . }}</li>
+                {{- else -}}
+                    {{- $currentPage := $.Site.GetPage ($.Scratch.Get "url") -}}
+                    {{- if $currentPage -}}
+                        {{- if $currentPage.IsPage -}}
+                            <li class="breadcrum-item current">{{ $currentPage.Title }}</li>
+                        {{- else -}}
+                            <li class="breadcrum-item"><span><a href="{{ $.Scratch.Get `url` }}">{{ $currentPage.Title }}</a></span></li>
                         {{- end -}}
                     {{- else -}}
                         <li class="breadcrum-item"><span><a href="{{ $.Scratch.Get `url` }}">{{ humanize . }}</a></span></li>
                     {{- end -}}
                 {{- end -}}
             {{- end -}}
-            </ul>
+        {{- end -}}
+    </ul>
 </section>

--- a/tests/e2e/tags.spec.ts
+++ b/tests/e2e/tags.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from '@playwright/test';
+
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:1313';
+
+test.describe('Tag functionality', () => {
+  test('visiting tags list', async ({ page }) => {
+    await page.goto(`${BASE_URL}/tags`);
+    // Verify we reached the tags page
+    await expect(page.getByRole('heading', { name: 'Tags', level: 1 })).toBeVisible();
+  });
+
+  test('verify there are 2 tags, each with 1 article', async ({ page }) => {
+    await page.goto(`${BASE_URL}/tags`);
+    await expect(page.locator('ul.list-taxonomy li')).toHaveCount(2);
+
+    // Each item shows how many articles
+    // e.g. "Lorem-Ipsum (1)" or "Sample (1)"
+    await expect(page.getByText('Sample (1)')).toBeVisible();
+  });
+
+  test('click on a tag -> renders the tag page', async ({ page }) => {
+    await page.goto(`${BASE_URL}/tags`);
+    await page.getByRole('link', { name: /Sample/ }).click();
+    // Verify tag page
+    await expect(page).toHaveURL(/\/tags\/sample/);
+    await expect(page.getByRole('heading', { name: 'Sample' })).toBeVisible();
+  });
+
+  test('tag page content links', async ({ page }) => {
+    // Go directly to the Sample tag page
+    await page.goto(`${BASE_URL}/tags/sample`);
+    // Verify any article link is visible (1 article)
+    const articleLink = page.locator('.post a[href*="/blog/sample/"]');
+    await expect(articleLink).toBeVisible();
+    await articleLink.click();
+    // Article should list the tags
+    await expect(page.locator('ul.tags li')).toHaveCount(2);
+  });
+});


### PR DESCRIPTION
Dusted up a bit the tags functionality in the theme with several improvements

Added new tags list for posts

<img width="1442" alt="SCR-20250113-snac" src="https://github.com/user-attachments/assets/08ec53ec-a87d-4597-97aa-d3bc160f2924" />


Modified default/sample content with tags
Created basic tag page

<img width="1447" alt="image" src="https://github.com/user-attachments/assets/b417bbb2-266c-4b04-9bd6-f80bf28ef039" />

Created basic tags list page
<img width="1426" alt="image" src="https://github.com/user-attachments/assets/c5c42747-b062-42dc-9502-1c6c69e251ba" />


Added tests for the tags functionality in the theme

<img width="1367" alt="image" src="https://github.com/user-attachments/assets/0570a85c-2e30-4e6c-a542-2b17fc7713da" />


The list pages are due for a restyling - but they give a basic functionality for now/. 