### PR TITLE
Display items as "dropups" as expected

### DIFF
--- a/assets/scss/adritian.scss
+++ b/assets/scss/adritian.scss
@@ -159,6 +159,10 @@ br {
     }
 }
 
+.dropdown-item.selected{
+    font-weight: bold;
+}
+
 #mobile-header-language-selector,
 #mobile-header-color-selector
 {
@@ -362,6 +366,13 @@ footer_links .nav-item .nav-link::after {
 
     .text-muted{
         color: rgba(255, 255, 255, .6) !important;
+    }
+
+    .dropdown-item.active,
+    .dropdown-item:active,
+    .dropdown-item:focus,
+    .dropdown-item:hover{
+        background-color: #478079
     }
 }
 /* end dark mode */

--- a/layouts/partials/selector-language.html
+++ b/layouts/partials/selector-language.html
@@ -21,7 +21,7 @@
       id="languages-dropdown-{{ $placement }}"
       data-bs-popper="static"
     >
-      <li class="dropdown-item current active">
+      <li class="dropdown-item current selected">
         <span>✔️ {{ .LanguageName }}</span>
       </li>
       {{ end }} 
@@ -29,7 +29,7 @@
       {{ range $.Translations }}
       <li class="dropdown-item choice">
         <a
-          class="translation btn-link nav-link show"
+          class="dropdown-item translation btn-link nav-link show"
           title="{{ .Language.LanguageName }}"
           href="{{ .Permalink }}"
           >{{ .Language.LanguageName }}</a

--- a/layouts/partials/selector-language.html
+++ b/layouts/partials/selector-language.html
@@ -6,7 +6,7 @@
     {{ if eq . $.Site.Language }}
     <button
       type="button"
-      class="btn btn-link nav-link py-2 px-0 px-lg-2 dropdown-toggle d-flex align-items-center show"
+      class="btn btn-link py-2 px-0 px-lg-2 dropdown-toggle d-flex align-items-center show"
       aria-expanded="false"
       aria-controls="languages-dropdown-{{ $placement }}"
       aria-expanded="true"

--- a/layouts/partials/selector-theme.html
+++ b/layouts/partials/selector-theme.html
@@ -3,7 +3,7 @@
 {{- $placement := .Scratch.Get "selectorPlacement" }}
 <div id='{{ .Scratch.Get "selectorPlacement" }}-color-selector' class='nav-item dropdown dropup {{ if eq $placement "mobile-header" }}nav-link{{ end }}'>
     <button
-      class="btn btn-link nav-link py-2 px-0 px-lg-2 dropdown-toggle d-flex align-items-center show"
+      class="btn btn-link py-2 px-0 px-lg-2 dropdown-toggle d-flex align-items-center show"
       id='bd-theme-{{ .Scratch.Get "selectorPlacement" }}'
       type="button"
       aria-expanded="true"


### PR DESCRIPTION
Solves #142 
Improved visual styling of the footer dropdowns.

![2025-01-15 20 17 50](https://github.com/user-attachments/assets/48ba8ff9-97c1-4cba-be77-663871fb9e70)

Found a couple of bugs that spill from this:
1. inconsistency across the 2 dropdowns (in padding)
2. not displaying currently active theme properly