### PR TITLE
Adapted code to work with multiple theme selectors

### DIFF
--- a/assets/js/color-modes.js
+++ b/assets/js/color-modes.js
@@ -21,9 +21,12 @@
       return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
     }
   
-    const setTheme = theme => {
+    function setTheme(theme) {
       if (theme === 'auto') {
-        document.documentElement.setAttribute('data-bs-theme', (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'))
+        document.documentElement.setAttribute(
+          'data-bs-theme',
+          window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+        )
       } else {
         document.documentElement.setAttribute('data-bs-theme', theme)
       }
@@ -32,31 +35,31 @@
     setTheme(getPreferredTheme())
   
     const showActiveTheme = (theme, focus = false) => {
-      const themeSwitcher = document.querySelector('#bd-theme-footer')
+      const themeSwitcher = document.querySelectorAll('.bd-theme-selector')
   
       if (!themeSwitcher) {
         return
       }
   
       const themeSwitcherText = document.querySelector('#bd-theme-text')
-      const activeTheme = document.querySelector('.current-theme')
-      const btnToActive = document.querySelector(`[data-bs-theme-value="${theme}"]`)
-      const iconOfActiveBtn = btnToActive.querySelector('span.theme-icon')
+      const activeTheme = document.querySelectorAll('.current-theme')
+      const btnToActive = document.querySelectorAll(`[data-bs-theme-value="${theme}"]`)
+      //const iconOfActiveBtn = btnToActive.querySelector('span.theme-icon')
 
   
       document.querySelectorAll('[data-bs-theme-value]').forEach(element => {
         element.classList.remove('active')
         element.setAttribute('aria-pressed', 'false')
       })
-  
-      btnToActive.classList.add('active')
-      btnToActive.setAttribute('aria-pressed', 'true')
-      activeTheme.textContent = btnToActive.textContent
-      const themeSwitcherLabel = `${themeSwitcherText.textContent} (${btnToActive.dataset.bsThemeValue})`
-      themeSwitcher.setAttribute('aria-label', themeSwitcherLabel)
-  
-      if (focus) {
-        themeSwitcher.focus()
+      for (const element of btnToActive){
+        element.setAttribute('aria-pressed', 'true')
+      }
+      for (const element of activeTheme) {
+        element.textContent = btnToActive[0].textContent
+      }
+      const themeSwitcherLabel = `${themeSwitcherText.textContent} (${btnToActive[0].dataset.bsThemeValue})`
+      for (const element of themeSwitcher) {
+        element.setAttribute('aria-label', themeSwitcherLabel)
       }
     }
   

--- a/layouts/partials/selector-theme.html
+++ b/layouts/partials/selector-theme.html
@@ -3,7 +3,7 @@
 {{- $placement := .Scratch.Get "selectorPlacement" }}
 <div id='{{ .Scratch.Get "selectorPlacement" }}-color-selector' class='nav-item dropdown dropup {{ if eq $placement "mobile-header" }}nav-link{{ end }}'>
     <button
-      class="btn btn-link py-2 px-0 px-lg-2 dropdown-toggle d-flex align-items-center show"
+      class="btn btn-link py-2 px-0 px-lg-2 dropdown-toggle d-flex align-items-center show bd-theme-selector"
       id='bd-theme-{{ .Scratch.Get "selectorPlacement" }}'
       type="button"
       aria-expanded="true"


### PR DESCRIPTION
![2025-01-15 21 25 54](https://github.com/user-attachments/assets/7796d2b1-115f-4020-bf1f-ac46d41c42c5)

Original code added in #114 
Broken in #143 by adding a new location for the selector - where the logic relied on Ids.

Changed to use classes and an iteration on elements (so there can be multiple theme selectors in the DOM).