### PR TITLE
Improved styling for footer items

### DIFF
--- a/assets/scss/_menu.scss
+++ b/assets/scss/_menu.scss
@@ -5,7 +5,7 @@ $transition: 280ms all 120ms ease-out;
 
 .language-selector {
   li.choice {
-    padding-left: 22px;
+    padding: 0;
   }
 
   .label {

--- a/assets/scss/adritian.scss
+++ b/assets/scss/adritian.scss
@@ -173,6 +173,14 @@ br {
 {
     font-size: inherit;
 }
+a.dropdown-item.translation,
+li.dropdown-item.current.selected {
+    width: 100%;
+    padding: 4px 10px;
+}
+li.dropdown-item.choice a{
+    padding-left: 30px;
+}
 
 html[data-bs-theme="dark"] {
     #dark-toggle {

--- a/layouts/partials/selector-language.html
+++ b/layouts/partials/selector-language.html
@@ -1,18 +1,19 @@
 {{/* indicates where the partial is placed 
  so far the placement can either be header or footer */}}
  {{- $placement := .Scratch.Get "selectorPlacement" }}
-<nav id='{{ $placement }}-language-selector' class='language-selector nav-item dropdown dropup {{ if eq $placement "mobile-header" }}nav-link{{ end }}'>
+<div id='{{ $placement }}-language-selector' class='language-selector nav-item dropdown dropup {{ if eq $placement "mobile-header" }}nav-link{{ end }}'>
     {{ range .Site.Languages }} 
     {{ if eq . $.Site.Language }}
     <button
-      type="button"
       class="btn btn-link py-2 px-0 px-lg-2 dropdown-toggle d-flex align-items-center show"
-      aria-expanded="false"
+      id='btn-select-language-{{ $placement }}'
+      type="button"
+      aria-expanded="true"
       aria-controls="languages-dropdown-{{ $placement }}"
       aria-expanded="true"
       data-bs-toggle="dropdown"
       data-bs-display="static"
-      aria-label="Select language"
+      aria-label='{{ i18n "language" }}'
     >
       <span class="label">{{ i18n "language" }}</span>
     </button>
@@ -29,7 +30,7 @@
       {{ range $.Translations }}
       <li class="dropdown-item choice">
         <a
-          class="dropdown-item translation btn-link nav-link show"
+          class="dropdown-item translation btn-link d-flex align-items-center show"
           title="{{ .Language.LanguageName }}"
           href="{{ .Permalink }}"
           >{{ .Language.LanguageName }}</a
@@ -37,4 +38,4 @@
       </li>
       {{ end }}
     </ul>
-  </nav>
+  </div>

--- a/tests/e2e/language-switch.spec.ts
+++ b/tests/e2e/language-switch.spec.ts
@@ -13,7 +13,7 @@ test.describe('Language switching functionality', () => {
     await expect(page.getByText('Experience').first()).toBeVisible();
 
     // Switch to Spanish
-    await page.locator('nav#footer-language-selector button').click();
+    await page.locator('div#footer-language-selector button').click();
     await page.getByText('Español').last().click();
 
     // Verify Spanish
@@ -22,7 +22,7 @@ test.describe('Language switching functionality', () => {
     await expect(page.getByText('Experiencia').first()).toBeVisible();
 
     // Switch to French
-    await page.locator('nav#footer-language-selector button').click();
+    await page.locator('div#footer-language-selector button').click();
     await page.getByText('Français').last().click();
 
     // Verify French


### PR DESCRIPTION
Both for the footer:
![2025-01-17 21 35 33](https://github.com/user-attachments/assets/f232bb82-6ef0-40ef-92fc-331fcb0d844b)

And for the mobile header:
![2025-01-17 21 36 16](https://github.com/user-attachments/assets/7281d9a3-6d50-4f98-aa15-59dd2c0e0a8e)

Both are more consistent now 💅 