### PR TITLE
Add indicator current color theme

### DIFF
--- a/assets/scss/adritian.scss
+++ b/assets/scss/adritian.scss
@@ -182,6 +182,10 @@ li.dropdown-item.choice a{
     padding-left: 30px;
 }
 
+.dropdown-menu button[aria-pressed="true"]{
+    font-weight: bold;
+}
+
 html[data-bs-theme="dark"] {
     #dark-toggle {
         span.dark{ 

--- a/tests/e2e/theme-switch.spec.ts
+++ b/tests/e2e/theme-switch.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from '@playwright/test';
+
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:1313';
+const FOOTER_THEME_SELECTOR = 'div#footer-color-selector button.bd-theme-selector';
+
+test.describe('Theme switching functionality', () => {
+  test('verifies bold styling of selected theme and updates on switch', async ({ page }) => {
+    // Go to homepage
+    await page.goto(BASE_URL);
+    
+    // Open theme dropdown
+    await page.locator(FOOTER_THEME_SELECTOR).click();
+    
+    // Verify initial Light theme is bold (font-weight: 700)
+    const lightButton = page.locator('#footer-color-selector .dropdown-item[data-bs-theme-value="light"]');
+    await expect(lightButton).toHaveCSS('font-weight', '700');
+    
+    // Switch to Dark theme
+    await page.locator('div#footer-color-selector .dropdown-item[data-bs-theme-value="dark"]').click();
+    
+    // Verify Dark theme is now bold and Light is not
+    const darkButton = page.locator('#footer-color-selector .dropdown-item[data-bs-theme-value="dark"]');
+    await expect(darkButton).toHaveCSS('font-weight', '700');
+    await expect(lightButton).toHaveCSS('font-weight', '400');
+    
+    // Switch to Auto theme
+    await page.locator(FOOTER_THEME_SELECTOR).click();
+    await page.locator('div#footer-color-selector .dropdown-item[data-bs-theme-value="auto"]').click();
+    
+    // Verify Auto theme is bold and others are not
+    const autoButton = page.locator('#footer-color-selector .dropdown-item[data-bs-theme-value="auto"]');
+    await expect(autoButton).toHaveCSS('font-weight', '700');
+    await expect(darkButton).toHaveCSS('font-weight', '400');
+    await expect(lightButton).toHaveCSS('font-weight', '400');
+  });
+
+  test('theme selection persists after page reload', async ({ page }) => {
+    // Go to homepage
+    await page.goto(BASE_URL);
+    
+    // Switch to Dark theme
+    await page.locator(FOOTER_THEME_SELECTOR).click();
+    await page.locator('div#footer-color-selector .dropdown-item[data-bs-theme-value="dark"]').click();
+    
+    // Reload page
+    await page.reload();
+    
+    // Open dropdown and verify Dark theme is still bold
+    await page.locator(FOOTER_THEME_SELECTOR).click();
+    const darkButton = page.locator('#footer-color-selector .dropdown-item[data-bs-theme-value="dark"]');
+    await expect(darkButton).toHaveCSS('font-weight', '700');
+  });
+});

--- a/tests/e2e/theme-switch.spec.ts
+++ b/tests/e2e/theme-switch.spec.ts
@@ -1,7 +1,13 @@
 import { test, expect } from '@playwright/test';
 
 const BASE_URL = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:1313';
-const FOOTER_THEME_SELECTOR = 'div#footer-color-selector button.bd-theme-selector';
+
+// Extract repeated selectors into constants
+const FOOTER_THEME_CONTAINER = 'div#footer-color-selector';
+const FOOTER_THEME_SELECTOR = `${FOOTER_THEME_CONTAINER} button.bd-theme-selector`;
+const FOOTER_THEME_LIGHT = `${FOOTER_THEME_CONTAINER} .dropdown-item[data-bs-theme-value="light"]`;
+const FOOTER_THEME_DARK = `${FOOTER_THEME_CONTAINER} .dropdown-item[data-bs-theme-value="dark"]`;
+const FOOTER_THEME_AUTO = `${FOOTER_THEME_CONTAINER} .dropdown-item[data-bs-theme-value="auto"]`;
 
 test.describe('Theme switching functionality', () => {
   test('verifies bold styling of selected theme and updates on switch', async ({ page }) => {
@@ -12,23 +18,23 @@ test.describe('Theme switching functionality', () => {
     await page.locator(FOOTER_THEME_SELECTOR).click();
     
     // Verify initial Light theme is bold (font-weight: 700)
-    const lightButton = page.locator('#footer-color-selector .dropdown-item[data-bs-theme-value="light"]');
+    const lightButton = page.locator(FOOTER_THEME_LIGHT);
     await expect(lightButton).toHaveCSS('font-weight', '700');
     
     // Switch to Dark theme
-    await page.locator('div#footer-color-selector .dropdown-item[data-bs-theme-value="dark"]').click();
+    await page.locator(FOOTER_THEME_DARK).click();
     
     // Verify Dark theme is now bold and Light is not
-    const darkButton = page.locator('#footer-color-selector .dropdown-item[data-bs-theme-value="dark"]');
+    const darkButton = page.locator(FOOTER_THEME_DARK);
     await expect(darkButton).toHaveCSS('font-weight', '700');
     await expect(lightButton).toHaveCSS('font-weight', '400');
     
     // Switch to Auto theme
     await page.locator(FOOTER_THEME_SELECTOR).click();
-    await page.locator('div#footer-color-selector .dropdown-item[data-bs-theme-value="auto"]').click();
+    await page.locator(FOOTER_THEME_AUTO).click();
     
     // Verify Auto theme is bold and others are not
-    const autoButton = page.locator('#footer-color-selector .dropdown-item[data-bs-theme-value="auto"]');
+    const autoButton = page.locator(FOOTER_THEME_AUTO);
     await expect(autoButton).toHaveCSS('font-weight', '700');
     await expect(darkButton).toHaveCSS('font-weight', '400');
     await expect(lightButton).toHaveCSS('font-weight', '400');
@@ -40,14 +46,14 @@ test.describe('Theme switching functionality', () => {
     
     // Switch to Dark theme
     await page.locator(FOOTER_THEME_SELECTOR).click();
-    await page.locator('div#footer-color-selector .dropdown-item[data-bs-theme-value="dark"]').click();
+    await page.locator(FOOTER_THEME_DARK).click();
     
     // Reload page
     await page.reload();
     
     // Open dropdown and verify Dark theme is still bold
     await page.locator(FOOTER_THEME_SELECTOR).click();
-    const darkButton = page.locator('#footer-color-selector .dropdown-item[data-bs-theme-value="dark"]');
+    const darkButton = page.locator(FOOTER_THEME_DARK);
     await expect(darkButton).toHaveCSS('font-weight', '700');
   });
 });


### PR DESCRIPTION
Together with #156, fixes #151.

Added a "bold" indicator to the currently selected color theme, same as with the language selector.
Not changing the emoji in this case because each theme has one (for the languages that's not the case).

![2025-01-18 07 54 30](https://github.com/user-attachments/assets/ec6190dc-c302-46d9-a5d9-c97c231e711e)

Additionally, added a e2e playwright test for the functionality (it focuses on the footer).