### PR TITLE
Blog branch content

### DIFF
--- a/exampleSite/content/blog/_index.es.md
+++ b/exampleSite/content/blog/_index.es.md
@@ -1,0 +1,9 @@
+---
+title: "Blog de Demostración"
+date: 2023-01-01
+draft: false
+---
+
+Bienvenido al blog de demostración. Puedes personalizar (o eliminar) esta sección en el archivo `_index.md` de la carpeta `blog`. Puedes [leer sobre cómo organizar contenido en Hugo](https://gohugo.io/content-management/page-bundles/) en la documentación oficial.
+
+Los artículos a continuación se encuentran en la misma carpeta (`blog/`) y pueden estar en [cualesquiera de los formatos que Hugo soporta](https://gohugo.io/content-management/formats/) (Markdown, HTML, Emacs Org Mode, AsciiDoc, Pandoc o reStructuredText).

--- a/exampleSite/content/blog/_index.md
+++ b/exampleSite/content/blog/_index.md
@@ -1,0 +1,9 @@
+---
+title: "Demo Blog"
+date: 2023-01-01
+draft: false
+---
+
+Welcome to the demo blog. You can customize (or remove) this section in the `_index.md` file in the `blog` folder. You can [read about how to organize content in Hugo](https://gohugo.io/content-management/page-bundles/) in the official docs.
+
+The posts below are in the same folder (`blog/`) and can be in the [supported formats by hugo](https://gohugo.io/content-management/formats/) (Markdown, HTML, Emacs Org Mode, AsciiDoc, Pandoc, or reStructuredText).

--- a/exampleSite/content/blog/_index.md
+++ b/exampleSite/content/blog/_index.md
@@ -7,3 +7,5 @@ draft: false
 Welcome to the demo blog. You can customize (or remove) this section in the `_index.md` file in the `blog` folder. You can [read about how to organize content in Hugo](https://gohugo.io/content-management/page-bundles/) in the official docs.
 
 The posts below are in the same folder (`blog/`) and can be in the [supported formats by hugo](https://gohugo.io/content-management/formats/) (Markdown, HTML, Emacs Org Mode, AsciiDoc, Pandoc, or reStructuredText).
+
+You can use translations as well. 

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -19,6 +19,7 @@
         
         <div class="col-content" {{ if eq .Site.Params.blog.layout "sidebar" }}style="width: calc(100% - {{ .Site.Params.blog.sidebarWidth }}%)"{{ end }}>
           <h1 class="rad-fade-down rad-waiting rad-animate">{{ .Title }}</h1>
+          {{ .Content }}
           <div class="posts-list">
             {{ range .Pages }}
               <div class="row row--padded rad-animation-group rad-fade-down rad-waiting rad-animate section--border-bottom">

--- a/tests/e2e/blog.spec.ts
+++ b/tests/e2e/blog.spec.ts
@@ -1,0 +1,15 @@
+import { test, expect } from '@playwright/test';
+
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:1313';
+
+test.describe('Blog page content', () => {
+  test('should show "Demo Blog" heading and "Welcome to the demo blog" text', async ({ page }) => {
+    await page.goto(`${BASE_URL}/blog`);
+    
+    // Verify heading is displayed
+    await expect(page.getByRole('heading', { name: /demo blog/i })).toBeVisible();
+    
+    // Verify body text is displayed
+    await expect(page.getByText('Welcome to the demo blog')).toBeVisible();
+  });
+});


### PR DESCRIPTION
Added a missing functionality in the blog: rendering the "branch" content (ie: the blog description).

Added:
- rendering "branch content"
- updated blog content to show an example
- added a e2e test to verify that the content is rendered