### PR TITLE
Enhance blog post listing styles and functionality

### DIFF
--- a/assets/scss/_blog.scss
+++ b/assets/scss/_blog.scss
@@ -91,3 +91,35 @@
     }
   }
 }
+
+.posts-list-simple {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+
+  li.post {
+    padding: 1rem 0;
+    border-bottom: 1px solid var(--bs-border-color);
+
+    &:last-child {
+      border-bottom: none;
+    }
+
+    a {
+      color: var(--bs-body-color);
+      text-decoration: none;
+      font-size: 1.1rem;
+      font-weight: 500;
+
+      &:hover {
+        color: var(--bs-primary);
+      }
+    }
+
+    .meta {
+      font-size: 0.9rem;
+      color: var(--bs-secondary-color);
+      margin-top: 0.25rem;
+    }
+  }
+}

--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -228,3 +228,4 @@ sidebarWidth = "25" # percentage width of the sidebar
 showCategories = true
 showRecentPosts = true
 recentPostCount = 5
+listStyle = "summary" # options: simple, summary

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -21,11 +21,21 @@
           {{ end }}
         </ul>
       {{ else }}
-        <ul>
-          {{ range .Pages }}
-            {{ .Render "li" }}
-          {{ end }}
-        </ul>
+        {{ if eq .Site.Params.blog.listStyle "summary" }}
+          <div class="posts-list">
+            {{ range .Pages }}
+              <div class="row row--padded rad-animation-group rad-fade-down rad-waiting rad-animate section--border-bottom">
+                {{ .Render "summary" }}
+              </div>
+            {{ end }}
+          </div>
+        {{ else }}
+          <ul class="posts-list-simple">
+            {{ range .Pages }}
+              {{ .Render "li" }}
+            {{ end }}
+          </ul>
+        {{ end }}
       {{ end }}
     </section>
   </main>

--- a/tests/e2e/list-style.spec.ts
+++ b/tests/e2e/list-style.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from '@playwright/test';
+
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:1313';
+
+test.describe('List style functionality', () => {
+  test('summary style shows full post previews', async ({ page }) => {
+    await page.goto(`${BASE_URL}/tags/sample`);
+    
+    // Check for summary style elements
+    const articleSummary = page.locator('article.post.summary');
+    await expect(articleSummary).toBeVisible();
+    
+    // Verify summary components are present
+    await expect(page.locator('article.post.summary h2').first()).toBeVisible();
+    await expect(page.locator('article.post.summary .post-meta').first()).toBeVisible();
+    await expect(page.locator('article.post.summary .post-summary').first()).toBeVisible();
+    await expect(page.locator('article.post.summary .btn-outline-secondary').first()).toBeVisible();
+    
+    // Verify tags are displayed
+    await expect(page.locator('ul.tags li')).toHaveCount(2);
+  });
+
+}); 

--- a/tests/e2e/tags.spec.ts
+++ b/tests/e2e/tags.spec.ts
@@ -23,16 +23,16 @@ test.describe('Tag functionality', () => {
     await page.getByRole('link', { name: /Sample/ }).click();
     // Verify tag page
     await expect(page).toHaveURL(/\/tags\/sample/);
-    await expect(page.getByRole('heading', { name: 'Sample' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Sample blog content 1' })).toBeVisible();
   });
 
   test('tag page content links', async ({ page }) => {
     // Go directly to the Sample tag page
     await page.goto(`${BASE_URL}/tags/sample`);
     // Verify any article link is visible (1 article)
-    const articleLink = page.locator('.post a[href*="/blog/sample/"]');
-    await expect(articleLink).toBeVisible();
-    await articleLink.click();
+    const articleLink = page.locator('a[href*="/blog/sample/"]');
+    await expect(articleLink.first()).toBeVisible();
+    await articleLink.first().click();
     // Article should list the tags
     await expect(page.locator('ul.tags li')).toHaveCount(2);
   });


### PR DESCRIPTION
Solves #146

<img width="1386" alt="image" src="https://github.com/user-attachments/assets/b814c4c0-ad34-40e7-8030-b01262e1c832" />


- Added new SCSS styles for a simple post list layout in _blog.scss.
- Updated list.html to conditionally render posts based on the selected list style (simple or summary) from hugo.toml.
- Introduced a new parameter 'listStyle' in hugo.toml to allow for flexible post listing options.
- Updated/added e2e tests

If the functionality is used, it could be extended with more "list modes" (ie: thumbnail/gallery mode).