### PR TITLE
Improve multilingual support for experience links

### DIFF
--- a/layouts/partials/experience.html
+++ b/layouts/partials/experience.html
@@ -17,7 +17,7 @@
                 {{ end }}
                 {{ range first $totalCount (sort $xp "Date" "desc") }}
                 <div class="experience">
-                    <a href="{{.Permalink | relLangURL }}">
+                    <a href="{{.Permalink | relURL }}">
                         {{/* The context, ".", is now each one of the pages as it goes
                         through the loop */}}
                         <div class="experience__date">{{ .Params.duration }}</div>


### PR DESCRIPTION
https://github.com/zetxek/adritian-free-hugo-theme/issues/161
This pull request includes a small change to the `layouts/partials/experience.html` file. The change modifies the method used to generate relative URLs for experience links.

* [`layouts/partials/experience.html`](diffhunk://#diff-72dc0628c6edef5024993b5771a79927e95010adab70da325535d7a167a854a5L20-R20): Changed the method from `relLangURL` to `relURL` for generating relative URLs in the experience section.