### PR TITLE
Improved README.md for module first use

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,9 +110,18 @@ Note: the theme supports both Hugo modules and git submodules. To install the th
 
 - Create a new Hugo site (this will create a new folder): `hugo new site <your website's name>`
 - Enter the newly created folder: `cd <your website's name>/`
+- Initialize hugo modules: `hugo mod init github.com/<your_user>/<your_project>`
 - Install PostCSS: execute `npm i -D postcss postcss-cli autoprefixer` from the top-level site folder [check [Hugo's official docs](https://gohugo.io/hugo-pipes/postcss/)].
-- Clone the adritian-free-hugo-theme: `git clone https://github.com/zetxek/adritian-free-hugo-theme.git themes/adritian-free-hugo-theme`.
-- Replace the `hugo.toml` file in the project's root directory with themes/adritian-free-hugo-theme/exampleSite/config.toml: `cp themes/adritian-free-hugo-theme/exampleSite/hugo.toml hugo.toml` (*executed from the website root folder*)
+- Add adritian-free-hugo-theme as a module dependency, by adding
+  ```
+  [module]
+  [[module.imports]]
+    path = 'github.com/zetxek/adritian-free-hugo-theme'
+  ```
+  To your `hugo.toml` file, and executing `hugo mod get -u`
+  
+- Replace the `hugo.toml` file in the project's root directory with the contents of [themes/adritian-free-hugo-theme/exampleSite/config.toml](https://github.com/zetxek/adritian-free-hugo-theme/blob/main/exampleSite/hugo.toml). If you are using the git submodules, you can execute `cp themes/adritian-free-hugo-theme/exampleSite/hugo.toml hugo.toml` (*executed from the website root folder*), otherwise just copy and paste the contents.
+- Create the file `data/homepage.yml`, with the initial contents of the [`exampleSite/data/homepage.yml`](https://github.com/zetxek/adritian-free-hugo-theme/blob/main/exampleSite/data/homepage.yml). This will serve as your starting point to customize your home content ✍️
 - Start Hugo with `hugo server -D`
 - 🎉 The theme is alive on http://localhost:1313/
 


### PR DESCRIPTION
As seen in #177 , the documentation to use the theme as a module misses some steps.
This is a temporary fix until #173 is ready to be merged, to clarify the usage for new users.

This is a summary/wrap-up of the changes I did in https://github.com/Luosua/Luosua.github.io/pull/1 to fix the first-time setup.