### PR TITLE
Updating release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,29 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@v4
+              
+            - name: Set up Go
+              uses: actions/setup-go@v4
+              
+            - name: Set up Node.js
+              uses: actions/setup-node@v4
+              
+            - name: Install Go dependencies
+              run: go mod download
+              
+            - name: Install NPM dependencies
+              run: npm ci
+              
+            - name: Get version
+              id: get_version
+              run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+              
+            - name: Create ZIP archive
+              run: zip -r "adritian-free-hugo-theme-${{ steps.get_version.outputs.VERSION }}.zip" . -x "*.git*"
+              
             - name: Release
               uses: softprops/action-gh-release@v2
               with:
                 generate_release_notes: true
+                files: "adritian-free-hugo-theme-${{ steps.get_version.outputs.VERSION }}.zip"
   

--- a/README.md
+++ b/README.md
@@ -47,11 +47,13 @@ You have two reference implementations of the theme provided:
 
 #### Install Hugo
 
-To use `adritian-free-hugo-theme` you need to install Hugo by following https://gohugo.io/getting-started/installing/.
+This is a theme for the website generator Hugo - so to use it you need to install Hugo by following https://gohugo.io/getting-started/installing/.
 
-We recommend installing the theme as a [Hugo module](https://gohugo.io/hugo-modules/) (recommended, and explained below).
+**We recommend installing the theme as a [Hugo module](https://gohugo.io/hugo-modules/) (recommended, and explained below).**
 
-Other alternative is to use [git submodules](https://gohugo.io/getting-started/quick-start/#create-a-site), or to [download the theme as a zip file](https://github.com/zetxek/adritian-free-hugo-theme/releases), and copy the files to your site. But that will lead to your site being "stuck in time" and more difficult to upgrade. **This is not recommended or supported directly**.
+Other alternative is to use [git submodules](https://gohugo.io/getting-started/quick-start/#create-a-site), or to [download the theme as a zip file](https://github.com/zetxek/adritian-free-hugo-theme/releases), and copy the files to your site`*`. But that will lead to your site being "stuck in time" and more difficult to upgrade. **This is not recommended or supported directly**.
+
+> **On the release files:** `*` from the version `v1.5.4` the theme available as a zip file in the [releases page](https://github.com/zetxek/adritian-free-hugo-theme/releases) contains the `node_modules` folder, so you don't need to install it separately. This is provided as a convenience for edge cases that might have problems installing the theme as a module, or downloading many files.__
 
 ### As a Hugo Module (recommended)
 


### PR DESCRIPTION
Solves #180, by bundling the `node_modules` folder in the zip file for the released versions.
Tested with https://github.com/zetxek/adritian-free-hugo-theme/releases/tag/v1.5.4.