### PR TITLE
Adding more theme tags

### DIFF
--- a/theme.toml
+++ b/theme.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/zetxek/adritian-free-hugo-theme"
 demosite = "https://zetxek.github.io/adritian-demo/"
 min_version = "0.123.0"
 
-tags = ["responsive", "clean", "light", "personal", "bootstrap", "blog", "portfolio", "dark", "light", "multilingual"]
+tags = ["responsive", "clean", "light", "personal", "bootstrap", "blog", "portfolio", "dark", "dark-mode", "light", "multilingual", "contact"]
 
 features = [
     "widgets",


### PR DESCRIPTION
So the theme appears in

https://themes.gohugo.io/tags/dark-mode/
https://themes.gohugo.io/tags/contact/

(as both features are supported)
