### PR TITLE
Update color of `ol`/`ul` items within homepage `section`

### DIFF
--- a/assets/scss/_raditian.scss
+++ b/assets/scss/_raditian.scss
@@ -683,7 +683,6 @@ textarea:focus {
     padding-left: 15px;
     font-size: 16px;
     font-weight: 300;
-    color: rgba(0, 0, 0, 0.6);
     line-height: 1.24;
     margin-bottom: 12px;
     text-align: left;

--- a/assets/scss/_raditian.scss
+++ b/assets/scss/_raditian.scss
@@ -681,7 +681,6 @@ textarea:focus {
     display: block;
     position: relative;
     padding-left: 15px;
-    font-size: 16px;
     font-weight: 300;
     line-height: 1.24;
     margin-bottom: 12px;

--- a/assets/scss/_raditian.scss
+++ b/assets/scss/_raditian.scss
@@ -686,15 +686,20 @@ textarea:focus {
     margin-bottom: 12px;
     text-align: left;
 }
+.section ol, 
+.section ul{
+    padding-left: 1.2rem;
+}
+
 .section li::before {
     content: "";
     display: block;
     position: absolute;
     left: 0;
-    top: 10px;
-    width: 4px;
-    height: 4px;
-    border-radius: 2px;
+    top: 8px;
+    width: 6px;
+    height: 6px;
+    border-radius: 4px;
     background-color: #000;
 }
 .header.collapse.show::before,

--- a/assets/scss/adritian.scss
+++ b/assets/scss/adritian.scss
@@ -93,7 +93,6 @@ h4 {
     }
 }
 p {
-    margin-bottom: 30px;
     font-size: 16px;
     font-weight: 300;
     line-height: 28px;

--- a/assets/scss/adritian.scss
+++ b/assets/scss/adritian.scss
@@ -275,9 +275,6 @@ footer_links .nav-item .nav-link::after {
     .h1, .h2, .h3, .h4, .h5, .h6, h1, h2, h3, h4, h5, h6{
         color: #fff !important;
     }
-    .section li{
-        color: $light-text-emphasis-dark !important;
-    }
     .section li::before{
         background-color: $light-text-emphasis-dark !important;
     }

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -77,7 +77,7 @@
   translation: "Who am I?"
 
 - id: "about_content"
-  translation:  <p class="lead">
+  translation:  '<p class="lead">
       Here you can add some information about you. A small excerpt that describes 
       your experience, for example.   
       </p>
@@ -85,9 +85,17 @@
       You explain something about your academic/study background, as well as your
       preferred areas of work. Think of this area as context-setting for the experience
       that you will describe below. Why did you change jobs? What drove you to take a 
-      new gig? Even if you are not looking for a job, it's a good way to hint about
+      new gig? Even if you are not looking for a job, it’s a good way to hint about
       what kind of projects you are interested in.
-    </p>
+      </p>
+      <p class="lead">
+        You can also add a list of topics, for example:
+        <ul>
+          <li>Topic 1</li>
+          <li>Topic 2</li>
+          <li>Topic 3</li>
+        </ul>
+      </p>'
 
 - id: "about_button"
   translation: "About Me"

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -80,16 +80,15 @@
   translation:  '<p class="lead">
       Here you can add some information about you. A small excerpt that describes 
       your experience, for example.   
-      </p>
-      <p class="lead">
+      </br>
       You explain something about your academic/study background, as well as your
       preferred areas of work. Think of this area as context-setting for the experience
       that you will describe below. Why did you change jobs? What drove you to take a 
       new gig? Even if you are not looking for a job, it’s a good way to hint about
       what kind of projects you are interested in.
-      </p>
-      <p class="lead">
+      </br>
         You can also add a list of topics, for example:
+      </br>
         <ul>
           <li>Topic 1</li>
           <li>Topic 2</li>


### PR DESCRIPTION
Before:

the items are "grayed out", and the spacing is a bit off (exaggerated):
<img width="1222" alt="SCR-20250208-oscn-2" src="https://github.com/user-attachments/assets/ed0e27fd-9412-4be5-a1a4-34f60c3d70a7" />

After:
same color as the text, using the same spacing as bootstrap (`1rem` margin-bottom).
<img width="1375" alt="SCR-20250208-qzft" src="https://github.com/user-attachments/assets/442691fa-d167-4fca-9325-23f6aa6fc792" />


Reference for bootstrap:
https://getbootstrap.com/docs/5.3/examples/starter-template/
<img width="1031" alt="image" src="https://github.com/user-attachments/assets/5525cb8d-5f7b-489b-a79a-b30a97a9c05e" />

Discovered while testing https://github.com/zetxek/adrianmoreno.info/pull/282 (minor text adjustments, but the formatting was off).