### PR TITLE
Improve experience section HTML structure and content rendering

### DIFF
--- a/layouts/partials/experience.html
+++ b/layouts/partials/experience.html
@@ -15,18 +15,18 @@
                 {{ end }}
                 {{ range first $totalCount (sort $xp "Date" "desc") }}
                 <div class="experience">
-                    <a href="{{.Permalink | relURL }}">
+                    <a href="{{.Permalink | relURL }}" class="experience__link">
                         <div class="experience__header">
-                            {{ $img := resources.Get .Params.companyLogo }}
-                            {{ with $img }}
-                            {{ $imgWebp := $img.Resize (printf "%dx%d webp q75 Lanczos picture" $img.Width $img.Height) }}
+                            {{- $img := resources.Get .Params.companyLogo }}
+                            {{- with $img }}
+                            {{- $imgWebp := $img.Resize (printf "%dx%d webp q75 Lanczos picture" $img.Width $img.Height) }}
                             <img 
                                 src="{{ $imgWebp.RelPermalink }}" 
                                 alt="{{ .Params.company }} logo"
                                 class="experience__company-logo"
                                 loading="lazy"
-                            >
-                            {{ end }}
+                            />
+                            {{- end }}
                             <div class="experience__meta">
                                 <div class="experience__date">{{ .Params.duration }}</div>
                                 <div class="experience__title">{{ .Params.jobTitle }}</div>
@@ -35,7 +35,7 @@
                             </div>
                             <div class="experience__description d-none d-print-block">
                                 <h1>{{ .Params.title }}</h1>
-                                {{ .Content | safeHTML }}
+                                {{ .Content | safeHTML | transform.Plainify }}
                             </div>
                         </div>
                     </a>


### PR DESCRIPTION
Solves #201. 

- Use `transform.Plainify` to clean up experience description content (thanks @jmooring at  https://discourse.gohugo.io/t/removing-links-in-summary/53328/2?u=zetxek 🙌  :-) 
- Add `experience__link` class to experience anchor
- Minor HTML formatting improvements

https://github.com/user-attachments/assets/a832b2ed-127c-481a-9219-31b291e3b0c2
