### PR TITLE
Fix theme selector to support multiple instances

### DIFF
--- a/assets/js/color-modes.js
+++ b/assets/js/color-modes.js
@@ -41,7 +41,7 @@
         return
       }
   
-      const themeSwitcherText = document.querySelector('#bd-theme-text')
+      const themeSwitcherText = document.querySelectorAll('.bd-theme-text')
       const activeTheme = document.querySelectorAll('.current-theme')
       const btnToActive = document.querySelectorAll(`[data-bs-theme-value="${theme}"]`)
       //const iconOfActiveBtn = btnToActive.querySelector('span.theme-icon')
@@ -57,7 +57,7 @@
       for (const element of activeTheme) {
         element.textContent = btnToActive[0].textContent
       }
-      const themeSwitcherLabel = `${themeSwitcherText.textContent} (${btnToActive[0].dataset.bsThemeValue})`
+      const themeSwitcherLabel = `${themeSwitcherText[0].textContent} (${btnToActive[0].dataset.bsThemeValue})`
       for (const element of themeSwitcher) {
         element.setAttribute('aria-label', themeSwitcherLabel)
       }

--- a/layouts/partials/selector-theme.html
+++ b/layouts/partials/selector-theme.html
@@ -15,14 +15,14 @@
         >{{ i18n "theme_auto_short" }}</span
       >
       <span class="current-theme">{{ i18n "theme_auto" }}</span>
-      <span class="d-lg-none ms-2 visually-hidden" id="bd-theme-text"
+      <span class="d-lg-none ms-2 visually-hidden bd-theme-text" id="bd-theme-text-{{ $placement }}"
         >{{ i18n "toggle_theme" }}</span
       >
     </button>
     <ul
       id="theme-dropdown-{{ $placement }}"
       class="dropdown-menu dropdown-menu-end dropup"
-      aria-labelledby="bd-theme-text"
+      aria-labelledby="bd-theme-text-{{ $placement }}"
       data-bs-popper="static"
     >
       <li>


### PR DESCRIPTION
- Update color-modes.js to use querySelectorAll for theme text and switcher elements
- Modify selector-theme.html to add unique IDs for theme text and dropdown labels
- Ensure theme switching works correctly with multiple theme selectors on a page