### PR TITLE
Refactor of language and color selectors, adding tests for additional configuration files

### DIFF
--- a/.github/workflows/test-example-site.yml
+++ b/.github/workflows/test-example-site.yml
@@ -64,6 +64,10 @@ jobs:
       - name: Run Playwright tests
         run: npm run test:e2e
 
+      - name: Stop hugo server
+        run: |
+          killall hugo
+
       - name: Build site (no menus)
         run: |
           cd exampleSite

--- a/.github/workflows/test-example-site.yml
+++ b/.github/workflows/test-example-site.yml
@@ -55,6 +55,15 @@ jobs:
         if: steps.cache-playwright.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps
 
+      - name: Build site (no menus)
+        run: |
+          cd exampleSite
+          hugo server --themesDir ../.. --buildDrafts --buildFuture --bind 0.0.0.0 --config hugo.toml,hugo.disablemenu.toml &
+          sleep 10
+
+      - name: Run Playwright tests (no menus)
+        run: npm run test:e2e:no-menus
+
       - name: Build and serve demo site
         run: |
           cd exampleSite
@@ -68,14 +77,6 @@ jobs:
         run: |
           killall hugo
 
-      - name: Build site (no menus)
-        run: |
-          cd exampleSite
-          hugo server --themesDir ../.. --buildDrafts --buildFuture --bind 0.0.0.0 --config hugo.toml,hugo.disablemenu.toml &
-          sleep 10
-
-      - name: Run Playwright tests (no menus)
-        run: npm run test:e2e:no-menus
 
       - name: Get the failure count
         id: tests

--- a/.github/workflows/test-example-site.yml
+++ b/.github/workflows/test-example-site.yml
@@ -64,6 +64,15 @@ jobs:
       - name: Run Playwright tests
         run: npm run test:e2e
 
+      - name: Build site (no menus)
+        run: |
+          cd exampleSite
+          hugo server --themesDir ../.. --buildDrafts --buildFuture --bind 0.0.0.0 --config hugo.toml,hugo.disablemenu.toml &
+          sleep 10
+
+      - name: Run Playwright tests (no menus)
+        run: npm run test:e2e:no-menus
+
       - name: Get the failure count
         id: tests
         run: |

--- a/.github/workflows/test-example-site.yml
+++ b/.github/workflows/test-example-site.yml
@@ -64,18 +64,20 @@ jobs:
       - name: Run Playwright tests (no menus)
         run: npm run test:e2e:no-menus
 
-      - name: Build and serve demo site
+      - name: Stop hugo server
+        run: |
+          killall hugo
+
+      - name: Build and serve demo site (default; with menus)
         run: |
           cd exampleSite
           hugo server --themesDir ../.. --buildDrafts --buildFuture --bind 0.0.0.0 &
           sleep 10
 
-      - name: Run Playwright tests
+      - name: Run Playwright tests (default; with menus)
         run: npm run test:e2e
 
-      - name: Stop hugo server
-        run: |
-          killall hugo
+
 
 
       - name: Get the failure count

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -2,6 +2,10 @@
 
 This documentation is meant to help you upgrade across versions, when potentially breaking changes are introduced.
 
+## v1.5.12
+
+The options to control how the language and theme selectors are displayed in the header and footer have been refactored, to enable control over each placement individually (footer and header).
+
 ## v1.5.7
 
 In order to have the (optional) print improvements for the CV, you need to add the following to your `config.toml` file:

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,6 +6,23 @@ This documentation is meant to help you upgrade across versions, when potentiall
 
 The options to control how the language and theme selectors are displayed in the header and footer have been refactored, to enable control over each placement individually (footer and header).
 
+There are 3 placements that can be controlled. For the color selector, it's always available; for the languae selector, it's available if the site is multilingual.
+
+The configuration syntax is as follows:
+```
+[params.languages.selector.disable]
+footer = false
+header = false
+mobileHeader = false
+
+[params.colorTheme.selector.disable]
+footer = false
+header = false
+mobileHeader = false
+```
+
+The default value is assumed to be `false` for all placements, meaning that the selector is displayed in all placements by default.
+
 ## v1.5.7
 
 In order to have the (optional) print improvements for the CV, you need to add the following to your `config.toml` file:

--- a/assets/scss/_menu.scss
+++ b/assets/scss/_menu.scss
@@ -3,48 +3,30 @@ $color-border: #478079;
 $color-dark: scale-color($color, $lightness: -30%);
 $transition: 280ms all 120ms ease-out;
 
-.language-selector {
+.underline-item {
+  border-bottom: 1px solid $color;
+}
+
+// prevents the menu content from not being visible
+// https://github.com/zetxek/adritian-free-hugo-theme/issues/206
+.header .navbar .nav-item.language-selector, 
+.header .navbar .nav-item.theme-selector {
+  overflow: visible;
+
+  .nav-link{
+    padding: 0;
+  }
+}
+
+.language-selector,
+.theme-selector {
   li.choice {
     padding: 0;
   }
-
-  .label {
-    color: $color;
-  }
-
-  .dropdown-toggle::after {
-    color: $color;
-  }
 }
 
-#mobile-header-language-selector{
-  .label {
-    color: black;
-  }
-}
-#mobile-header-language-selector .dropdown-toggle::after{
-  color: black;
-}
-
-#footer-color-selector {
-    .dropdown-toggle::after {
-      color: $color;
-    }
-
-    .current-theme{
-      color: $color;
-    }
-  
-}
-
-@include color-mode(dark){
-  #mobile-header-language-selector{
-    .label {
-      color: white;
-    }
-  }
-  #mobile-header-language-selector .dropdown-toggle::after{
-    color: white;
-  }
-  
+.footer_right button.btn,
+.footer_right .btn-link:hover,
+.footer_right .btn-link:focus {
+  color: white;
 }

--- a/exampleSite/hugo.disablemenu.toml
+++ b/exampleSite/hugo.disablemenu.toml
@@ -1,0 +1,9 @@
+[params.languages.selector.disable]
+footer = true
+header = true
+mobileHeader = true
+
+[params.colorTheme.selector.disable]
+footer = true
+header = true
+mobileHeader = true

--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -98,6 +98,7 @@ enable = true
 [params.languages.selector.disable]
 footer = false
 header = false
+mobileHeader = false
 
 [languages]
 [languages.en]
@@ -293,7 +294,7 @@ URL = "scss/adritian.scss"
 [params.colorTheme.selector.disable]
 footer = false
 header = false
-
+mobileHeader = false
 ## by default we allow override AND automatic selection
 
 [params.blog]

--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -97,6 +97,7 @@ enable = true
 
 [params.languages.selector.disable]
 footer = false
+header = false
 
 [languages]
 [languages.en]
@@ -288,6 +289,10 @@ URL = "scss/adritian.scss"
 #  [params.colorTheme.selector.disable]
 #  footer = true
 
+
+[params.colorTheme.selector.disable]
+footer = false
+header = false
 
 ## by default we allow override AND automatic selection
 

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -35,6 +35,7 @@
             
             {{- if not .Site.Params.colorTheme.selector.disable.footer }}
             {{ .Scratch.Set "selectorPlacement" "footer" }}
+            {{ .Scratch.Set "dropdownDirection" "up" }}
             {{ partial "selector-theme.html" . }}
             {{- end }}
           </div>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -24,7 +24,7 @@
           </ul>
         </div>
         <div class="footer_right col-12 col-lg-2 mb-3 mb-lg-0 text-center text-lg-end">
-          <div class="d-flex flex-column flex-lg-row justify-content-center align-items-center gap-2">
+          <div class="d-flex flex-column flex-lg-row justify-content-center align-items-center gap-2 d-grid col-12 ">
             {{- if hugo.IsMultilingual }} 
             {{- if not .Site.Params.languages.selector.disable.footer }}
             {{ .Scratch.Set "selectorPlacement" "footer" }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -28,6 +28,7 @@
             {{- if hugo.IsMultilingual }} 
             {{- if not .Site.Params.languages.selector.disable.footer }}
             {{ .Scratch.Set "selectorPlacement" "footer" }}
+            {{ .Scratch.Set "dropdownDirection" "up" }}
             {{ partial "selector-language.html" . }}
             {{- end }} 
             {{- end }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -47,31 +47,28 @@
                 >{{ i18n "nav_home" }}</a
               >
             </li>
-            {{ range .Site.Menus.header }}
+            {{- range .Site.Menus.header }}
             <li class="nav-item">
               <a data-scroll class="nav-link" href="{{ .URL | relURL }}"
                 >{{ .Name | upper }}</a
               >
             </li>
-
-            
-            {{ end }}
-            {{ .Scratch.Set "selectorPlacement" "header" }}
-            <li class="nav-item dropdown">
-            {{ partial "selector-language.html" . }}
-            </li>
-            
-            {{ .Scratch.Set "selectorPlacement" "mobile-header" }}
+            {{- end }}
             
             {{- if hugo.IsMultilingual }} 
-            {{- if not .Site.Params.languages.selector.disable.footer }}
-            <li class="nav-item">
+            {{- if not .Site.Params.languages.selector.disable.header }}
+            {{ .Scratch.Set "selectorPlacement" "header" }}
+            {{ .Scratch.Set "dropdownDirection" "down" }}
+         
+            <li class="dropdown language-selector">
             {{ partial "selector-language.html" . }}
             </li>
             {{- end }}
             {{- end }}
-            <li class="nav-item">
-            {{ partial "selector-theme.html" . }}
+            <li class="dropdown theme-selector">
+              {{ .Scratch.Set "selectorPlacement" "header" }}
+              {{ .Scratch.Set "dropdownDirection" "down" }}  
+              {{ partial "selector-theme.html" . }}
             </li>
           </ul>
         </div>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -59,13 +59,13 @@
             {{- if not .Site.Params.languages.selector.disable.header }}
             {{ .Scratch.Set "selectorPlacement" "header" }}
             {{ .Scratch.Set "dropdownDirection" "down" }}         
-            <li class="dropdown language-selector">
+            <li class="dropdown language-selector nav-item">
             {{ partial "selector-language.html" . }}
             </li>
             {{- end }}
             {{- end }}
             {{- if not .Site.Params.colorTheme.selector.disable.header }}
-            <li class="dropdown theme-selector">
+            <li class="dropdown theme-selector nav-item">
               {{ .Scratch.Set "selectorPlacement" "header" }}
               {{ .Scratch.Set "dropdownDirection" "down" }}  
               {{ partial "selector-theme.html" . }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -53,7 +53,14 @@
                 >{{ .Name | upper }}</a
               >
             </li>
+
+            
             {{ end }}
+            {{ .Scratch.Set "selectorPlacement" "header" }}
+            <li class="nav-item dropdown">
+            {{ partial "selector-language.html" . }}
+            </li>
+            
             {{ .Scratch.Set "selectorPlacement" "mobile-header" }}
             
             {{- if hugo.IsMultilingual }} 

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -58,18 +58,19 @@
             {{- if hugo.IsMultilingual }} 
             {{- if not .Site.Params.languages.selector.disable.header }}
             {{ .Scratch.Set "selectorPlacement" "header" }}
-            {{ .Scratch.Set "dropdownDirection" "down" }}
-         
+            {{ .Scratch.Set "dropdownDirection" "down" }}         
             <li class="dropdown language-selector">
             {{ partial "selector-language.html" . }}
             </li>
             {{- end }}
             {{- end }}
+            {{- if not .Site.Params.colorTheme.selector.disable.header }}
             <li class="dropdown theme-selector">
               {{ .Scratch.Set "selectorPlacement" "header" }}
               {{ .Scratch.Set "dropdownDirection" "down" }}  
               {{ partial "selector-theme.html" . }}
             </li>
+            {{- end }}
           </ul>
         </div>
 

--- a/layouts/partials/selector-language.html
+++ b/layouts/partials/selector-language.html
@@ -1,41 +1,29 @@
-{{/* indicates where the partial is placed 
- so far the placement can either be header or footer */}}
- {{- $placement := .Scratch.Get "selectorPlacement" }}
- {{- $direction := .Scratch.Get "dropdownDirection" }}
-<div id='{{ $placement }}-language-selector' class='language-selector dropdown {{ if  (eq $direction "up") }}dropup{{ end }} {{ if eq $placement "mobile-header" }}nav-link{{ end }}'>
-    {{ range .Site.Languages }} 
-    {{ if eq . $.Site.Language }}
-    <button
-      class="btn btn-link py-2 px-0 px-lg-2 dropdown-toggle d-flex align-items-center show"
-      id='btn-select-language-{{ $placement }}'
-      type="button"
-      aria-expanded="true"
-      aria-controls="languages-dropdown-{{ $placement }}"
-      data-bs-toggle="dropdown"
-      data-bs-display="static"
-      aria-label='{{ i18n "language" }}'
-    >
-      <span class="label">{{ i18n "language" }}</span>
-    </button>
-    <ul
-      class='dropdown-menu dropdown-menu-end {{ if  (eq $direction "up") }}dropup{{ end }}'
-      id="languages-dropdown-{{ $placement }}"
-      data-bs-popper="static"
-    >
-      <li class="dropdown-item current selected">
-        <span>✔️ {{ .LanguageName }}</span>
-      </li>
-      {{ end }} 
-      {{ end }} 
-      {{ range $.Translations }}
-      <li class="dropdown-item choice">
-        <a
-          class="dropdown-item translation btn-link d-flex align-items-center show"
-          title="{{ .Language.LanguageName }}"
-          href="{{ .Permalink }}"
-          >{{ .Language.LanguageName }}</a
-        >
-      </li>
-      {{ end }}
-    </ul>
-  </div>
+{{/* indicates where the partial is placed
+so far the placement can either be header or footer */}}
+{{- $placement := .Scratch.Get "selectorPlacement" }}
+{{- $direction := .Scratch.Get "dropdownDirection" }}
+<div id='{{ $placement }}-language-selector'
+  class='d-grid gap-2 col-6 mx-auto nav-link dropdown {{ if  (eq $direction "up") }}dropup{{ end }} {{ if eq $placement "mobile-header" }}nav-link{{ end }}'>
+  {{ range .Site.Languages }}
+  {{ if eq . $.Site.Language }}
+  <button class="btn btn-link py-2 px-0 px-lg-2 dropdown-toggle d-flex align-items-center show"
+    id='btn-select-language-{{ $placement }}' type="button" aria-expanded="true"
+    aria-controls="languages-dropdown-{{ $placement }}" data-bs-toggle="dropdown" data-bs-display="static"
+    aria-label='{{ i18n "language" }}'>
+    <span class="label">{{ i18n "language" }}</span>
+  </button>
+  <ul class='dropdown-menu dropdown-menu-end {{ if  (eq $direction "up") }}dropup{{ end }}'
+    id="languages-dropdown-{{ $placement }}" data-bs-popper="static">
+    <li class="dropdown-item current selected">
+      <span>✔️ {{ .LanguageName }}</span>
+    </li>
+    {{ end }}
+    {{ end }}
+    {{ range $.Translations }}
+    <li class="dropdown-item choice">
+      <a class="dropdown-item translation btn-link d-flex align-items-center show" title="{{ .Language.LanguageName }}"
+        href="{{ .Permalink }}">{{ .Language.LanguageName }}</a>
+    </li>
+    {{ end }}
+  </ul>
+</div>

--- a/layouts/partials/selector-language.html
+++ b/layouts/partials/selector-language.html
@@ -1,7 +1,8 @@
 {{/* indicates where the partial is placed 
  so far the placement can either be header or footer */}}
  {{- $placement := .Scratch.Get "selectorPlacement" }}
-<div id='{{ $placement }}-language-selector' class='language-selector nav-item dropdown dropup {{ if eq $placement "mobile-header" }}nav-link{{ end }}'>
+ {{- $direction := .Scratch.Get "dropdownDirection" }}
+<div id='{{ $placement }}-language-selector' class='language-selector dropdown {{ if  (eq $direction "up") }}dropup{{ end }} {{ if eq $placement "mobile-header" }}nav-link{{ end }}'>
     {{ range .Site.Languages }} 
     {{ if eq . $.Site.Language }}
     <button
@@ -17,7 +18,7 @@
       <span class="label">{{ i18n "language" }}</span>
     </button>
     <ul
-      class='dropdown-menu dropdown-menu-end {{ if not (eq $placement "mobile-header") }}dropup{{ end }}'
+      class='dropdown-menu dropdown-menu-end {{ if  (eq $direction "up") }}dropup{{ end }}'
       id="languages-dropdown-{{ $placement }}"
       data-bs-popper="static"
     >

--- a/layouts/partials/selector-theme.html
+++ b/layouts/partials/selector-theme.html
@@ -1,7 +1,8 @@
 {{/* indicates where the partial is placed 
   so far the placement can either be header or footer */}}
 {{- $placement := .Scratch.Get "selectorPlacement" }}
-<div id='{{ .Scratch.Get "selectorPlacement" }}-color-selector' class='nav-item dropdown dropup {{ if eq $placement "mobile-header" }}nav-link{{ end }}'>
+{{- $direction := .Scratch.Get "dropdownDirection" }}
+<div id='{{ .Scratch.Get "selectorPlacement" }}-color-selector' class='dropdown {{ if eq $direction "up" }}dropup{{ end }} {{ if eq $placement "mobile-header" }}nav-link{{ end }}'>
     <button
       class="btn btn-link py-2 px-0 px-lg-2 dropdown-toggle d-flex align-items-center show bd-theme-selector"
       id='bd-theme-{{ .Scratch.Get "selectorPlacement" }}'
@@ -21,7 +22,7 @@
     </button>
     <ul
       id="theme-dropdown-{{ $placement }}"
-      class="dropdown-menu dropdown-menu-end dropup"
+      class="dropdown-menu dropdown-menu-end {{ if eq $direction "up" }}dropup{{ end }}"
       aria-labelledby="bd-theme-text-{{ $placement }}"
       data-bs-popper="static"
     >

--- a/layouts/partials/selector-theme.html
+++ b/layouts/partials/selector-theme.html
@@ -1,66 +1,38 @@
-{{/* indicates where the partial is placed 
-  so far the placement can either be header or footer */}}
+{{/* indicates where the partial is placed
+so far the placement can either be header or footer */}}
 {{- $placement := .Scratch.Get "selectorPlacement" }}
 {{- $direction := .Scratch.Get "dropdownDirection" }}
-<div id='{{ .Scratch.Get "selectorPlacement" }}-color-selector' class='dropdown {{ if eq $direction "up" }}dropup{{ end }} {{ if eq $placement "mobile-header" }}nav-link{{ end }}'>
-    <button
-      class="btn btn-link py-2 px-0 px-lg-2 dropdown-toggle d-flex align-items-center show bd-theme-selector"
-      id='bd-theme-{{ .Scratch.Get "selectorPlacement" }}'
-      type="button"
-      aria-expanded="true"
-      data-bs-toggle="dropdown"
-      data-bs-display="static"
-      aria-label='{{ i18n "toggle_theme" }}'
-    >
-      <span class="theme-icon auto d-none" aria-hidden="true"
-        >{{ i18n "theme_auto_short" }}</span
-      >
-      <span class="current-theme">{{ i18n "theme_auto" }}</span>
-      <span class="d-lg-none ms-2 visually-hidden bd-theme-text" id="bd-theme-text-{{ $placement }}"
-        >{{ i18n "toggle_theme" }}</span
-      >
-    </button>
-    <ul
-      id="theme-dropdown-{{ $placement }}"
-      class="dropdown-menu dropdown-menu-end {{ if eq $direction "up" }}dropup{{ end }}"
-      aria-labelledby="bd-theme-text-{{ $placement }}"
-      data-bs-popper="static"
-    >
-      <li>
-        <button
-          type="button"
-          class="dropdown-item d-flex align-items-center active"
-          data-bs-theme-value="light"
-          aria-pressed="true"
-        >
-          {{ i18n "theme_light" }}
-        </button>
-      </li>
-      <li>
-        <button
-          type="button"
-          class="dropdown-item d-flex align-items-center"
-          data-bs-theme-value="dark"
-          aria-pressed="false"
-        >
-          {{ i18n "theme_dark" }}
-          <span class="theme-icon dark d-none" aria-hidden="true"
-            >{{ i18n "theme_dark_short" }}</span
-          >
-        </button>
-      </li>
-      <li>
-        <button
-          type="button"
-          class="dropdown-item d-flex align-items-center"
-          data-bs-theme-value="auto"
-          aria-pressed="false"
-        >
-          {{ i18n "theme_auto" }}
-          <span class="theme-icon light d-none" aria-hidden="true"
-            >{{ i18n "theme_light_short" }}</span
-          >
-        </button>
-      </li>
-    </ul>
-  </div>
+<div id='{{ .Scratch.Get "selectorPlacement" }}-color-selector'
+  class='d-grid gap-2 col-6 mx-auto nav-link dropdown {{ if eq $direction "up" }}dropup{{ end }} {{ if eq $placement "mobile-header" }}nav-link{{ end }}'>
+  <button class="btn btn-link py-2 px-0 px-lg-2 dropdown-toggle d-flex align-items-center show bd-theme-selector"
+    id='bd-theme-{{ .Scratch.Get "selectorPlacement" }}' type="button" aria-expanded="true" data-bs-toggle="dropdown"
+    data-bs-display="static" aria-label='{{ i18n "toggle_theme" }}'>
+    <span class="theme-icon auto d-none" aria-hidden="true">{{ i18n "theme_auto_short" }}</span>
+    <span class="current-theme">{{ i18n "theme_auto" }}</span>
+    <span class="d-lg-none ms-2 visually-hidden bd-theme-text" id="bd-theme-text-{{ $placement }}">{{ i18n
+      "toggle_theme" }}</span>
+  </button>
+  <ul id="theme-dropdown-{{ $placement }}" class="dropdown-menu dropdown-menu-end {{ if eq $direction " up" }}dropup{{
+    end }}" aria-labelledby="bd-theme-text-{{ $placement }}" data-bs-popper="static">
+    <li>
+      <button type="button" class="dropdown-item d-flex align-items-center active" data-bs-theme-value="light"
+        aria-pressed="true">
+        {{ i18n "theme_light" }}
+      </button>
+    </li>
+    <li>
+      <button type="button" class="dropdown-item d-flex align-items-center" data-bs-theme-value="dark"
+        aria-pressed="false">
+        {{ i18n "theme_dark" }}
+        <span class="theme-icon dark d-none" aria-hidden="true">{{ i18n "theme_dark_short" }}</span>
+      </button>
+    </li>
+    <li>
+      <button type="button" class="dropdown-item d-flex align-items-center" data-bs-theme-value="auto"
+        aria-pressed="false">
+        {{ i18n "theme_auto" }}
+        <span class="theme-icon light d-none" aria-hidden="true">{{ i18n "theme_light_short" }}</span>
+      </button>
+    </li>
+  </ul>
+</div>

--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
     "serve": "hugo server --source exampleSite --themesDir ../.. --logLevel debug",
     "build": "hugo build --source exampleSite --themesDir ../.. --logLevel debug --minify",
     "test": "npm-run-all build --parallel --continue-on-error --aggregate-output test-*",
-    "test:e2e": "playwright test",
+    "test:e2e": "export TEST_NO_MENUS=false; playwright test",
+    "test:e2e:no-menus": "export TEST_NO_MENUS=true; playwright test",
     "test:e2e:ui": "playwright test --ui",
-    "test:e2e:debug": "playwright test --debug"
+    "test:e2e:debug": "playwright test --debug",
   },
   "devDependencies": {
     "@playwright/test": "^1.49.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test:e2e": "export TEST_NO_MENUS=false; playwright test",
     "test:e2e:no-menus": "export TEST_NO_MENUS=true; playwright test",
     "test:e2e:ui": "playwright test --ui",
-    "test:e2e:debug": "playwright test --debug",
+    "test:e2e:debug": "playwright test --debug"
   },
   "devDependencies": {
     "@playwright/test": "^1.49.1",

--- a/tests/e2e/basic.spec.ts
+++ b/tests/e2e/basic.spec.ts
@@ -24,6 +24,8 @@ test.describe('Theme basic functionality', () => {
   });
 
   test('theme switcher works', async ({ page }) => {
+    test.skip(process.env.TEST_NO_MENUS === 'true', 'Skipping test because TEST_NO_MENUS is true');
+
     // set the browser theme preference to "light"
     // Emulate dark color scheme
     await page.emulateMedia({ colorScheme: 'dark' });
@@ -88,4 +90,17 @@ test.describe('Theme basic functionality', () => {
     const mainContent = page.locator('#main-content');
     await expect(mainContent).toBeFocused();
   });
+});
+
+test('footer_right should contain exactly 2 dropdown element for language and theme', async ({ page }) => {
+ test.skip(process.env.TEST_NO_MENUS === 'true', 'Skipping test because TEST_NO_MENUS is true');
+
+  await page.goto(`${BASE_URL}/disable-menu/`);
+
+  // Verify footer and footer_right exist
+  await expect(page.locator('footer')).toBeAttached();
+  await expect(page.locator('footer .footer_right')).toBeAttached();
+
+  // Verify exactly 2 dropdown elements exist within footer_right
+  await expect(page.locator('footer .footer_right .dropdown')).toHaveCount(2);
 });

--- a/tests/e2e/language-switch.spec.ts
+++ b/tests/e2e/language-switch.spec.ts
@@ -4,6 +4,8 @@ const BASE_URL = 'http://localhost:1313';
 
 test.describe('Language switching functionality', () => {
   test('switches between languages and verifies lang attribute', async ({ page }) => {
+    test.skip(process.env.TEST_NO_MENUS === 'true', 'Skipping test because TEST_NO_MENUS is true');
+
     // Go to homepage
     await page.goto(BASE_URL);
     
@@ -46,6 +48,8 @@ test.describe('Language switching functionality', () => {
   });
 
   test('preserves translations across page types', async ({ page }) => {
+    test.skip(process.env.TEST_NO_MENUS === 'true', 'Skipping test because TEST_NO_MENUS is true');
+
     // Go to French experience page
     await page.goto(`${BASE_URL}/fr/experience`);
     

--- a/tests/e2e/no-menus.spec.ts
+++ b/tests/e2e/no-menus.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from '@playwright/test';
+
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:1313';
+
+test.describe('Site without menus', () => {
+  // Read environment variable TEST_NO_MENUS
+  test.skip(process.env.TEST_NO_MENUS !== 'true', 'Skipping test because TEST_NO_MENUS is true');
+
+  test('page should not have navigation menus when disabled', async ({ page }) => {
+    // Navigate to the site with disabled menus
+    await page.goto(`${BASE_URL}/disable-menu/`);
+
+    // Verify header still exists but doesn't contain navigation
+    await expect(page.locator('header')).toBeAttached();
+    
+    // Verify language selector is not present
+    await expect(page.locator('#selector-language')).not.toBeAttached();
+    
+    // Verify main menu elements are not present
+    await expect(page.locator('#main-menu')).not.toBeAttached();
+    await expect(page.locator('#main-menu-mobile')).not.toBeAttached();
+
+    // Verify the page still has basic required elements
+    await expect(page.locator('main')).toBeAttached();
+    await expect(page.locator('footer')).toBeAttached();
+  });
+
+
+  test('footer_right should exist but contain no dropdown elements', async ({ page }) => {
+    await page.goto(`${BASE_URL}/disable-menu/`);
+
+    // Verify footer and footer_right exist
+    await expect(page.locator('footer')).toBeAttached();
+    await expect(page.locator('footer .footer_right')).toBeAttached();
+
+    // Verify no dropdown elements exist within footer_right
+    await expect(page.locator('footer .footer_right .dropdown')).not.toBeAttached();
+  });
+
+  test('content should still be properly displayed', async ({ page }) => {
+    await page.goto(`${BASE_URL}`);
+
+    // Verify main content area exists and is visible
+    const mainContent = page.locator('#main-content');
+    await expect(mainContent).toBeVisible();
+    await expect(mainContent.locator('.display-1')).toBeVisible();
+
+    // Verify page title is still present
+    await expect(page.locator('h1').first()).toBeVisible();
+  });
+
+  // 
+}); 

--- a/tests/e2e/theme-switch.spec.ts
+++ b/tests/e2e/theme-switch.spec.ts
@@ -11,6 +11,8 @@ const FOOTER_THEME_AUTO = `${FOOTER_THEME_CONTAINER} .dropdown-item[data-bs-them
 
 test.describe('Theme switching functionality', () => {
   test('verifies bold styling of selected theme and updates on switch', async ({ page }) => {
+    test.skip(process.env.TEST_NO_MENUS === 'true', 'Skipping test because TEST_NO_MENUS is true');
+
     // Go to homepage
     await page.goto(BASE_URL);
     
@@ -41,6 +43,8 @@ test.describe('Theme switching functionality', () => {
   });
 
   test('theme selection persists after page reload', async ({ page }) => {
+    test.skip(process.env.TEST_NO_MENUS === 'true', 'Skipping test because TEST_NO_MENUS is true');
+
     // Go to homepage
     await page.goto(BASE_URL);
     


### PR DESCRIPTION
Fixing #206.

Modified configuration items, and removed redundant code and unnecessary (S)CSS code.
 
The idea is to have choice of placement of the items in:
- general menu (yes/no)
- mobile menu (yes/no)
- footer (yes/no) __there's no mobile split, as the menu is the same__

https://github.com/user-attachments/assets/b93e4417-f9ae-49b5-b28e-4aff7d0dd047


Additionally, added an extra CI step to run the E2E tests a second time, with an extra configuration file that disables the menus for color switching and language switching.

New config options:
```

[params.languages.selector.disable]
footer = false
header = false
mobileHeader = false

[params.colorTheme.selector.disable]
footer = false
header = false
mobileHeader = false
```

Pending

- [x] implementation
- [x] figure a test for this functionality