### PR TITLE
[199][Feedback wanted] Documentation on how to customize content

### DIFF
--- a/assets/scss/_blog.scss
+++ b/assets/scss/_blog.scss
@@ -1,4 +1,10 @@
 .blog {
+
+  article.post.summary a{
+    color: #478079; 
+  }
+
+
   .has-sidebar {
     display: flex;
     flex-wrap: wrap;

--- a/assets/scss/_blog.scss
+++ b/assets/scss/_blog.scss
@@ -1,6 +1,6 @@
 .blog {
 
-  article.post.summary a{
+  .post .post-title a{
     color: #478079; 
   }
 

--- a/assets/scss/_raditian.scss
+++ b/assets/scss/_raditian.scss
@@ -1388,7 +1388,7 @@ li.book-content p{
 }
 
 article.post.summary h2{
-    font-size: 24px
+    font-size: 40px
 }
 .post-summary{
     margin-top: 20px;

--- a/exampleSite/content/blog/getting-started.md
+++ b/exampleSite/content/blog/getting-started.md
@@ -1,0 +1,392 @@
+---
+title: 'Create your own version of the site'
+date: 2025-02-11T14:38:33+02:00
+draft: false
+type: 'blog'
+tags: 
+  - sample
+  - lorem-ipsum
+---
+
+One of the most common questions is how to get started with the theme. 
+
+### Creating a site
+
+This theme is for the content management system [Hugo](https://gohugo.io/), so that will be a pre-requirement.
+Make sure that you install the `extended` version of Hugo, as the theme uses SCSS for styling, as well as image optimization.
+
+A very good place to start is the Quick start guide: [https://gohugo.io/getting-started/quick-start/](https://gohugo.io/getting-started/quick-start/)
+
+_💡Tip:__ keep your repository clean and tidy by creating a [relevant `.gitignore` file](https://github.com/github/gitignore/blob/main/community/Golang/Hugo.gitignore) since the beginning:
+
+```
+# Generated files by hugo
+/public/
+/resources/_gen/
+/assets/jsconfig.json
+hugo_stats.json
+
+# Executable may be added to repository
+hugo.exe
+hugo.darwin
+hugo.linux
+
+# Temporary lock file while building
+/.hugo_build.lock
+```
+
+
+
+### Adding the theme
+
+Once you have a site created, you can add the theme to your site by following the instructions in the [README](https://github.com/zetxek/adritian-free-hugo-theme?tab=readme-ov-file#as-a-hugo-module-recommended). While there are multiple ways to add the theme, the recommended way is to use the Hugo Modules, the ones listed here.
+
+<details>
+<summary>Instructions to setup the theme as a hugo module</summary>
+
+1. Create a new Hugo site (this will create a new folder): `hugo new site <your website's name>`
+1. Enter the newly created folder: `cd <your website's name>/`
+1. Initialize the Hugo Module system in your site if you haven't already: `hugo mod init github.com/username/your-site` (_you don't need to host your website on GitHub, you can add anything as a name_)
+1. Replace the contents of your config file (`hugo.toml`) file by these: 
+
+
+<details>
+<summary>hugo.toml configuration</summary>
+
+```
+baseURL = "<your website url>"
+languageCode = "en"
+
+[module]
+[module.hugoVersion]
+# We use hugo.Deps to list dependencies, which was added in Hugo 0.92.0
+min = "0.92.0"
+
+[[module.imports]]
+path="github.com/zetxek/adritian-free-hugo-theme"
+
+## Base mounts - so your site's assets are available
+  [[module.mounts]]
+    source = "archetypes"
+    target = "archetypes"
+
+  [[module.mounts]]
+    source = "assets"
+    target = "assets"
+
+  [[module.mounts]]
+    source = "i18n"
+    target = "i18n"
+
+  [[module.mounts]]
+    source = "layouts" 
+    target = "layouts"
+
+  [[module.mounts]]
+    source = "static"
+    target = "static"
+
+# The following mounts are required for the theme to be able to load bootstrap
+# Remember also to copy the theme's `package.json` to your site, and run `npm install`
+[[module.mounts]]
+  source = "node_modules/bootstrap/scss"
+  target = "assets/scss/bootstrap"
+
+[[module.mounts]]
+  source = "node_modules/bootstrap/dist/js"
+  target = "assets/js/bootstrap"
+
+[[module.mounts]]
+  source = "node_modules/bootstrap/dist/js/bootstrap.bundle.min.js"
+  target = "assets/js/vendor/bootstrap.bundle.min.js"
+
+## Optional, if you want print improvements (to PDF/printed)
+[[module.mounts]]
+source = "node_modules/bootstrap-print-css/css/bootstrap-print.css"
+target = "assets/css/bootstrap-print.css"
+
+[params]
+
+  title = 'Your website title'
+  description = 'Your website description'
+  sections = ["showcase", "about", "education", "experience", "client-and-work", "testimonial", "contact", "newsletter"]
+
+  # If you want to display an image logo in the header, you can add it here
+  # logo = '/img/hugo.svg'
+  homepageExperienceCount = 6
+
+  [params.analytics]
+  ## Analytics parameters.
+  ### Supported so far: Vercel (Page Insights, Analytics)
+  ### And Google (Tag Manager, Analytics)
+
+  # controls vercel page insights - disabled by default
+  # to enable, just set to true
+  vercelPageInsights = false
+  vercelAnalytics = false
+  
+  # google analytics and tag manager. to enable, set "enabled" to true
+  # and add the tracking code (UA-something for analytics, GTM-something for tag manager)
+  [params.analytics.googleAnalytics]
+      code = "UA-XXXXX-Y"
+      enabled = false
+  [params.analytics.googleTagManager]
+      code = "GTM-XXXXX"
+      enabled = false
+
+[build]
+  [build.buildStats]
+    disableClasses = false
+    disableIDs = false
+    disableTags = false
+    enable = true
+
+[params.languages.selector.disable]
+  footer = false
+
+[languages]
+  [languages.en]
+    disabled = false
+    languageCode = 'en'
+    languageDirection = 'ltr'
+    languageName = 'English'
+    title = ''
+    weight = 0
+
+    [languages.en.menus]
+      [[languages.en.menus.header]]
+        name = 'About'
+        URL = '#about'
+        weight = 2
+      [[languages.en.menus.header]]
+        name = 'Portfolio'
+        URL = '#portfolio'
+        weight = 3
+      #  [[languages.en.menus.header]]
+      #  name = "Experience"
+      #  URL = "#experience"
+      #  weight = 4
+
+      [[languages.en.menus.header]]
+        name = "Blog"
+        URL = "/blog"
+        weight = 5
+
+      [[languages.en.menus.header]]
+        name = "Contact"
+        URL = "#contact"
+        weight = 6
+
+      [[languages.en.menus.footer]]
+        name = "About"
+        URL = "#about"
+        weight = 2
+
+      [[languages.en.menus.footer]]
+        name = "Portfolio"
+        URL = "#portfolio"
+        weight = 3
+
+      [[languages.en.menus.footer]]
+        name = "Contact"
+        URL = "#contact"
+        weight = 4
+
+
+  [languages.es]
+    disabled = false
+    languageCode = 'es'
+    languageDirection = 'ltr'
+    languageName = 'Español'
+    title = ''
+    weight = 0
+      [[languages.es.menus.header]]
+        name = 'Sobre mi'
+        URL = '/es/#about'
+        weight = 2
+      [[languages.es.menus.header]]
+        name = 'Portfolio'
+        URL = '/es/#portfolio'
+        weight = 3
+
+      #  [[languages.es.menus.header]]
+      #  name = "Experiencia"
+      #  URL = "/es/#experience"
+      #  weight = 4
+
+      [[languages.es.menus.header]]
+        name = "Blog"
+        URL = "/es/blog"
+        weight = 5
+
+      [[languages.es.menus.header]]
+        name = "Contacto"
+        URL = "/es/#contact"
+        weight = 6
+
+      [[languages.es.menus.footer]]
+        name = "Sobre mi"
+        URL = "/es/#about"
+        weight = 2
+
+      [[languages.es.menus.footer]]
+        name = "Portfolio"
+        URL = "/es/#portfolio"
+        weight = 3
+
+      [[languages.es.menus.footer]]
+        name = "Contact"
+        URL = "/es/#contact"
+        weight = 4
+
+  [languages.fr]
+    disabled = false
+    languageCode = 'fr'
+    languageDirection = 'ltr'
+    languageName = 'Français'
+    title = ''
+    weight = 0
+
+    [languages.fr.menus]
+      [[languages.fr.menus.header]]
+        name = 'About'
+        URL = '#about'
+        weight = 2
+      [[languages.fr.menus.header]]
+        name = 'Portfolio'
+        URL = '#portfolio'
+        weight = 3
+      #  [[languages.fr.menus.header]]
+      #  name = "Experience"
+      #  URL = "#experience"
+      #  weight = 4
+
+      [[languages.fr.menus.header]]
+        name = "Blog"
+        URL = "/blog"
+        weight = 5
+
+      [[languages.fr.menus.header]]
+        name = "Contact"
+        URL = "#contact"
+        weight = 6
+
+      [[languages.fr.menus.footer]]
+        name = "About"
+        URL = "#about"
+        weight = 2
+
+      [[languages.fr.menus.footer]]
+        name = "Portfolio"
+        URL = "#portfolio"
+        weight = 3
+
+      [[languages.fr.menus.footer]]
+        name = "Contact"
+        URL = "#contact"
+        weight = 4
+
+# Plugins
+[params.plugins]
+
+  # CSS Plugins
+  [[params.plugins.css]]
+  URL = "css/custom.css"
+  [[params.plugins.css]]
+  URL = "css/adritian-icons.css"
+  ## Optional, if you want print improvements (to PDF/printed)
+  [[params.plugins.css]]
+  URL = "css/bootstrap-print.css"
+  
+  # JS Plugins
+  [[params.plugins.js]]
+  URL = "js/rad-animations.js"
+  [[params.plugins.js]]
+  URL = "js/sticky-header.js"
+  [[params.plugins.js]]
+  URL = "js/library/fontfaceobserver.js"
+
+  # SCSS Plugins
+  [[params.plugins.scss]]
+  URL = "scss/adritian.scss"
+
+
+# theme/color style 
+[params.colorTheme]
+
+## the following configuration would disable automatic theme selection
+#  [params.colorTheme.auto]
+#    disable = true
+#  [params.colorTheme.forced]
+#    theme = "dark"
+
+## the following parameter will disable theme override in the footer
+#  [params.colorTheme.selector.disable]
+#  footer = true
+
+
+## by default we allow override AND automatic selection
+
+[params.blog]
+layout = "default" # options: default, sidebar
+sidebarWidth = "25" # percentage width of the sidebar
+showCategories = true
+showRecentPosts = true
+recentPostCount = 5
+listStyle = "summary" # options: simple, summary
+```
+</details>
+
+This configuration allows you to have a base to edit and adapt to your site, and see the available functionalities.
+Make sure to edit `baseURL`, `title` and `description`. You can edit the header links, as well as the languages to your needs.
+
+1. Get the module: `hugo mod get -u`
+1. Execute `hugo mod npm pack` - this will generate a `package.json` file in the root folder of your site, with the dependencies for the theme.
+1. Execute `npm install` - this will install the dependencies for the theme (including bootstrap)
+1. (Optional, to override the defaults) Create a file `data/homepage.yml` with the contents of the [`exampleSite/data/homepage.yml`](https://github.com/zetxek/adritian-free-hugo-theme/blob/main/exampleSite/data/homepage.yml) file, and customize to your needs.
+1. Start Hugo with `hugo server`...
+1. 🎉 The theme is alive on http://localhost:1313/ (if everything went well)
+
+</details>
+
+
+### Editing the theme content
+
+Currently the theme content is spread over multiple folders and files. We are working on simplifying this - but for now [this guide](https://adritian-demo.vercel.app/) should help you get started.
+
+Some of the key files are:
+
+
+- `config.toml`: Main configuration for your Hugo site. Here you can set the site title, description, and theme specific settings such as:
+    - menu structure (footer and header)
+    - analytics (vercel, google)
+    - blog settings (layout, sidebar contents, etc)
+    - As well as some **required settings** for the theme to work properly (`module.mounts`, `params.plugins.css`)
+
+- `data/homepage.yml`: homepage structure, content and sections - including social links, and the hero section.
+- `assets/`: Where you can store static assets such as images, CSS, and JavaScript files (you can add custom CSS and JS files with the `params.plugins.css` in `config.toml`).
+- `content/`: This is where your content files will live. The theme-specific ones are:
+    - `content/blog/`: For blog posts.
+    - `content/portfolio/`: For portfolio items.
+    - `content/project/`: For projects.
+    - `content/testimonial/`: For testimonials.
+    - `content/education/`: For education items.
+    - `content/experience/`: For experience items.
+    - `content/client-and-work/`: For client and work items.
+
+### Customizing the theme 
+
+Hugo allows you to customize the theme in many ways. You can override the theme's layouts, styles, and content.
+For that, you just need to locate the file you would like to change, copy it to your site's corresponding folder (`layouts`, `assets`, ...), and edit it.
+
+**Note**: if you do this you will not benefit from theme updates, and that could lead to bugs. You can keep an eye on the [UPGRADING.md](https://github.com/zetxek/adritian-free-hugo-theme/blob/main/UPGRADING.md) file.
+
+### Improving the theme
+
+Maybe some of the customizations you do are worth a share. If you think that your changes could be useful for others, feel free to open a pull request in the [GitHub repository](https://github.com/zetxek/adritian-free-hugo-theme/pulls) - collaborations are very welcome, especially if the contributions come from real-world use cases.
+
+### Publishing the site
+
+Once you have your site ready, you can publish it to the web. There are many ways to do this, but the recommended one is to use a service like [Vercel](https://vercel.com/) or [Github Pages](https://pages.github.com/). Both services offer free hosting for static sites, and they can be connected to your GitHub repository for automatic deployments.
+
+For that, you will need to have a CI/CD action that builds your site and deploys it to the service. You can find an example of a GitHub action in the demo site repository: [https://github.com/zetxek/adritian-demo/blob/main/.github/workflows/hugo.yml](https://github.com/zetxek/adritian-demo/blob/main/.github/workflows/hugo.yml)

--- a/exampleSite/content/blog/getting-started.md
+++ b/exampleSite/content/blog/getting-started.md
@@ -4,11 +4,11 @@ date: 2025-02-11T14:38:33+02:00
 draft: false
 type: 'blog'
 tags: 
-  - sample
-  - lorem-ipsum
+  - adritian
+  - guide
 ---
 
-One of the most common questions is how to get started with the theme. 
+This article is a guide to help you create your own version of the site using [Adritian](https://github.com/zetxek/adritian-free-hugo-theme). It will cover the main steps to get started with the theme, and how to customize it to your needs.
 
 ### Creating a site
 

--- a/exampleSite/content/projects/swiss-fintech.md
+++ b/exampleSite/content/projects/swiss-fintech.md
@@ -18,4 +18,22 @@ params:
 ## The content is used for the description of the project
 ---
 
-The Swiss Finance + Technology Association is the leading FinTech hub in Switzerland.
+Here you can add additional context, description, links, etc. 
+The content you see here comes from the contents of the `content/projects` folder.
+
+This project is in the file `projects/swiss-fintech.md`.
+
+In the markdown file frontmatter you can also define additional parameters, such as the link:
+
+```
+link: "https://www.adrianmoreno.info" # optional URL to link the logo to
+
+params:
+    button:
+        icon: "icon-arrow-right"
+        btnText: "Case Study"
+        URL: "https://www.adrianmoreno.info"
+    image:  
+        x: "images/works/swissfintech.jpg"
+        _2x: "images/works/swissfintech@2x.jpg"
+```

--- a/exampleSite/content/testimonial/graziella-nutella.md
+++ b/exampleSite/content/testimonial/graziella-nutella.md
@@ -15,4 +15,16 @@ params:
 ##
 ---
 
-Working with this freelancer has been an exceptional experience. They consistently deliver high-quality work, demonstrating a keen eye for detail and a deep understanding of the project requirements. Their professionalism and commitment to excellence are evident in every task they undertake. They are not only skilled and knowledgeable but also incredibly reliable and easy to work with. I highly recommend this freelancer to anyone looking for top-tier talent and a dependable partner.
+The content of this section comes from the `content/testimonial` folder contents. This that you see is in `content/testimonial/graziella-nutella.md`.
+
+You can also use parameters for configuration:
+
+```
+name: "Nutting Hill" # place/city/country for the experience. Fill-in.
+position: "Nutcracker" # from-to, for example "2022-2024". Fill-in.
+
+params:
+    image:
+        x: "images/testimonials/testimonial1.png" # example: "images/clients/asgardia.png"
+        _2x: "images/testimonials/testimonial1@2x.png" # example: "images/clients/asgardia@2x.png"
+```

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -63,7 +63,31 @@
   translation: "Let's dive into an example"
 
 - id: "showcase_description"
-  translation: "This is a high performance theme for the Hugo static site generator. This sample content can be edited in the locale files (as the theme supports translations). <br>You can download this theme from <a target='_blank' href='https://github.com/zetxek/adritian-free-hugo-theme'>github</a>, and see it live <a target='_blank' href='https://adritian-demo.vercel.app/'>as a demo site</a> or <a target='_blank' href='https://www.adrianmoreno.info'>a real one</a>.<br>You can find this content to edit in the theme.yaml file."
+  translation: "This is a high performance theme for the Hugo static site generator. 
+    This sample content can be edited in the locale files (as the theme supports translations).
+    <br>
+    You can download this theme from <a target='_blank' href='https://github.com/zetxek/adritian-free-hugo-theme'>github</a>, 
+    and see it live <a target='_blank' href='https://adritian-demo.vercel.app/'>as a demo site</a> 
+    or <a target='_blank' href='https://www.adrianmoreno.info'>a real one</a>.
+    <br>
+    The content you see so far in the homepage is:
+    <ul>
+      <li>Site logo/name: site config file (<code>hugo.toml</code>)</li>
+      <li>Site top menu: site config file (<code>hugo.toml</code>), look for the <code>[[languages.en.menus.header]]</code> section</li>
+      <li>This paragraph: <code>i18n/en.yaml</code> (for English)</li>
+    </ul>
+    Additionally, the order of the items in the homepage is configured in the <code>sections</code> array in the <code>hugo.toml</code> file:
+    <code>sections = [
+  \"showcase\",
+  \"about\",
+  \"education\",
+  \"experience\",
+  \"client-and-work\",
+  \"testimonial\",
+  \"contact\",
+  \"newsletter\",
+  ]</code><br/> 
+  The content of each section is defined in the <code>data/homepage.yml</code> file (ie: links to social sites, mail, ...)."
 
 - id: "showcase_button"
   translation: "Contact"

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -87,7 +87,9 @@
   \"contact\",
   \"newsletter\",
   ]</code><br/> 
-  The content of each section is defined in the <code>data/homepage.yml</code> file (ie: links to social sites, mail, ...)."
+  The content of each section is defined in the <code>data/homepage.yml</code> file (ie: links to social sites, mail, ...).
+  <br/>
+  If you scroll this page you will see some hints on where the content comes from - all the way to the footer menu. These links come from the site config file (<code>hugo.toml</code>), look for the <code>[[languages.en.menus.footer]]</code> section."
 
 - id: "showcase_button"
   translation: "Contact"

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -106,18 +106,10 @@
       your experience, for example.   
       </br>
       You explain something about your academic/study background, as well as your
-      preferred areas of work. Think of this area as context-setting for the experience
-      that you will describe below. Why did you change jobs? What drove you to take a 
-      new gig? Even if you are not looking for a job, it’s a good way to hint about
-      what kind of projects you are interested in.
-      </br>
-        You can also add a list of topics, for example:
-      </br>
-        <ul>
-          <li>Topic 1</li>
-          <li>Topic 2</li>
-          <li>Topic 3</li>
-        </ul>
+      preferred areas of work.
+      </p>
+      <p>The content for this section is defined in the <code>i18n/en.yaml</code> file, 
+      in the <code>about_content</code> item.
       </p>'
 
 - id: "about_button"
@@ -132,7 +124,10 @@
   translation: "Experience"
 
 - id: "experience_description"
-  translation: "This is where you can highlight a bit over your experience. Years of total experience, specialization, etc."
+  translation: '<p>This is where you can highlight a bit over your experience. Years of total experience, specialization, etc.
+      <br/>The content in this intro comes from the <code>i18n/en.yaml</code> file, in the <code>experience_description</code> item.
+      <br/>The content for each experience item (that you can click on the left) is defined in the <code>content/experience</code> folder, with one content item per experience, as in <code>job-1.md</code>, <code>job-2.md</code>, etc.
+      <br/>The content (text and URL) for the buttons below (where you can add links) comes from the translation file, <code>i18n/en.yaml</code>, in the <code>experience_button</code>, <code>experience_button_url</code>, <code>experience_button2</code>, <code>experience_button2_url</code>, <code>experience_button3</code>, <code>experience_button3_url</code> items.'
 
 - id: "experience_button"
   translation: "LinkedIn" 
@@ -199,19 +194,19 @@
   translation: "Phone Number"
 
 - id: "contact_phone_number"
-  translation: "+555 (11) 123 44 55"
+  translation: "Defined in i18n/en.yaml (contact_phone_number)"
 
 - id: "contact_email_title"
   translation: "Email"
 
 - id: "contact_email_email"
-  translation: '<a href="mailto:mail@example.com">mail@example.com</a>'
+  translation: 'Defined in i18n/en.yaml (contact_email_email)'
 
 - id: "contact_address_title"
   translation: "Address"
 
 - id: "contact_address_address"
-  translation: "Exact street/neighborhood (you can omit this)<br />Postcode, City"
+  translation: "Defined in i18n/en.yaml (contact_address_address)"
 
 - id: "contact_button"
   translation: "Send Message"

--- a/layouts/blog/summary.html
+++ b/layouts/blog/summary.html
@@ -1,6 +1,6 @@
 <article class="post summary col-12">
   <header>
-    <h2><a href="{{ .RelPermalink }}">{{ .Title }}</a></h2>
+    <h2 class="post-title"><a href="{{ .RelPermalink }}">{{ .Title }}</a></h2>
     <div class="post-meta">
       <div>
         <section>

--- a/layouts/partials/experience-description.html
+++ b/layouts/partials/experience-description.html
@@ -1,7 +1,7 @@
 <div class="container-experience">
   <div class="row">
     <h2>{{ i18n "experience_title" }}</h2>
-    <p class="lead">{{ i18n "experience_description" }}</p>
+    <p class="lead">{{ i18n "experience_description" | safeHTML }}</p>
   </div>
   <div class="row">
     {{ if .Site.Data.homepage.experience.button.enable }}

--- a/tests/e2e/tags.spec.ts
+++ b/tests/e2e/tags.spec.ts
@@ -11,7 +11,7 @@ test.describe('Tag functionality', () => {
 
   test('verify there are 2 tags, each with 1 article', async ({ page }) => {
     await page.goto(`${BASE_URL}/tags`);
-    await expect(page.locator('ul.list-taxonomy li')).toHaveCount(2);
+    await expect(page.locator('ul.list-taxonomy li')).toHaveCount(4);
 
     // Each item shows how many articles
     // e.g. "Lorem-Ipsum (1)" or "Sample (1)"

--- a/tests/e2e/tags.spec.ts
+++ b/tests/e2e/tags.spec.ts
@@ -15,7 +15,7 @@ test.describe('Tag functionality', () => {
 
     // Each item shows how many articles
     // e.g. "Lorem-Ipsum (1)" or "Sample (1)"
-    await expect(page.getByText('Sample (1)')).toBeVisible();
+    await expect(page.getByText('Sample (2)')).toBeVisible();
   });
 
   test('click on a tag -> renders the tag page', async ({ page }) => {

--- a/tests/e2e/tags.spec.ts
+++ b/tests/e2e/tags.spec.ts
@@ -15,7 +15,7 @@ test.describe('Tag functionality', () => {
 
     // Each item shows how many articles
     // e.g. "Lorem-Ipsum (1)" or "Sample (1)"
-    await expect(page.getByText('Sample (2)')).toBeVisible();
+    await expect(page.getByText('Sample (1)')).toBeVisible();
   });
 
   test('click on a tag -> renders the tag page', async ({ page }) => {


### PR DESCRIPTION
Testing an idea that came up in #199: what if the demo site (https://github.com/zetxek/adritian-demo, published in https://adritian-demo.vercel.app/) could serve as a visual guide on how to edit the content for the site?

It would be something like this:
<img width="1391" alt="image" src="https://github.com/user-attachments/assets/4339e893-6741-4fb9-9cd1-650a2d31f154" />

Right now the content is also in the theme, in the [`exampleSite` folder](https://github.com/zetxek/adritian-free-hugo-theme/tree/main/exampleSite). 
This made sense when the theme was using primarily git submodules, as this folder would also be checked out.

With Hugo modules, the `exampleSite` folder is not visible for the users. Maybe it's time to ditch it?