### PR TITLE
Add adritian-theme-helper package to project dependencies and automate initial content/config

### DIFF
--- a/.github/workflows/test-module-init.yml
+++ b/.github/workflows/test-module-init.yml
@@ -27,7 +27,7 @@ jobs:
               working-directory: ./test-site
               run: |
                     hugo mod init github.com/zetxek/test-site
-                    hugo mod get -u github.com/zetxek/adritian-free-hugo-theme@54251dbe635253798a845e4ce92237b4b3a13b70
+                    hugo mod get -u github.com/zetxek/adritian-free-hugo-theme@d3853b613a5cc5a7fb2029d49b1e6bc37a9e8694
 
             - name: Configure Hugo module in hugo.toml
               working-directory: ./test-site

--- a/.github/workflows/test-module-init.yml
+++ b/.github/workflows/test-module-init.yml
@@ -27,12 +27,7 @@ jobs:
               working-directory: ./test-site
               run: |
                     hugo mod init github.com/zetxek/test-site
-                    hugo mod get github.com/zetxek/adritian-free-hugo-theme@9b519a5e76b0f54c96aa5e6b7af80f7201675d82
- 
-            - name: Download modules
-              working-directory: ./test-site
-              run: |
-                    hugo mod get -u
+                    hugo mod get -u github.com/zetxek/adritian-free-hugo-theme@9b519a5e76b0f54c96aa5e6b7af80f7201675d82
 
             - name: Pack dependencies
               working-directory: ./test-site

--- a/.github/workflows/test-module-init.yml
+++ b/.github/workflows/test-module-init.yml
@@ -27,7 +27,14 @@ jobs:
               working-directory: ./test-site
               run: |
                     hugo mod init github.com/zetxek/test-site
-                    hugo mod get -u github.com/zetxek/adritian-free-hugo-theme@9b519a5e76b0f54c96aa5e6b7af80f7201675d82
+                    hugo mod get -u github.com/zetxek/adritian-free-hugo-theme@54251dbe635253798a845e4ce92237b4b3a13b70
+
+            - name: Configure Hugo module in hugo.toml
+              working-directory: ./test-site
+              run: |
+                    echo '[module]
+                    [[module.imports]]
+                    path = "github.com/zetxek/adritian-free-hugo-theme"' > hugo.toml
 
             - name: Pack dependencies
               working-directory: ./test-site

--- a/.github/workflows/test-module-init.yml
+++ b/.github/workflows/test-module-init.yml
@@ -28,11 +28,6 @@ jobs:
               run: |
                     hugo mod init github.com/zetxek/test-site
                     hugo mod get github.com/zetxek/adritian-free-hugo-theme
-                
-            - name: Copy theme configuration
-              working-directory: ./test-site
-              run: |
-                    curl -O https://raw.githubusercontent.com/zetxek/adritian-free-hugo-theme/refs/heads/main/exampleSite/hugo.toml
  
             - name: Download modules
               working-directory: ./test-site
@@ -48,6 +43,11 @@ jobs:
               working-directory: ./test-site
               run: |
                     npm install
+
+            - name: Run helper script (copy config and content)
+              working-directory: ./test-site
+              run: |
+                    ./node_modules/adritian-theme-helper/dist/scripts/download-content.js
 
             - name: Run build
               working-directory: ./test-site

--- a/.github/workflows/test-module-init.yml
+++ b/.github/workflows/test-module-init.yml
@@ -27,7 +27,7 @@ jobs:
               working-directory: ./test-site
               run: |
                     hugo mod init github.com/zetxek/test-site
-                    hugo mod get -u github.com/zetxek/adritian-free-hugo-theme@776523ec0e0254b7877496ca7067de1a7f435592
+                    hugo mod get -u github.com/zetxek/adritian-free-hugo-theme@0a7778936da6b180db1e4750d4cd8f276b392b37
 
             - name: Configure Hugo module in hugo.toml
               working-directory: ./test-site

--- a/.github/workflows/test-module-init.yml
+++ b/.github/workflows/test-module-init.yml
@@ -27,7 +27,7 @@ jobs:
               working-directory: ./test-site
               run: |
                     hugo mod init github.com/zetxek/test-site
-                    hugo mod get -u github.com/zetxek/adritian-free-hugo-theme@0a7778936da6b180db1e4750d4cd8f276b392b37
+                    hugo mod get -u github.com/zetxek/adritian-free-hugo-theme@734a62b233ba386ae0326b1cb3f7323081789928
 
             - name: Configure Hugo module in hugo.toml
               working-directory: ./test-site

--- a/.github/workflows/test-module-init.yml
+++ b/.github/workflows/test-module-init.yml
@@ -27,7 +27,7 @@ jobs:
               working-directory: ./test-site
               run: |
                     hugo mod init github.com/zetxek/test-site
-                    hugo mod get -u github.com/zetxek/adritian-free-hugo-theme@d3853b613a5cc5a7fb2029d49b1e6bc37a9e8694
+                    hugo mod get -u github.com/zetxek/adritian-free-hugo-theme@776523ec0e0254b7877496ca7067de1a7f435592
 
             - name: Configure Hugo module in hugo.toml
               working-directory: ./test-site

--- a/.github/workflows/test-module-init.yml
+++ b/.github/workflows/test-module-init.yml
@@ -34,10 +34,20 @@ jobs:
               run: |
                     hugo mod npm pack
 
+            - name: (debug) Cat package.json
+              working-directory: ./test-site
+              run: |
+                    cat package.json
+
             - name: Npm install (bootstrap)
               working-directory: ./test-site
               run: |
                     npm install
+
+            - name: (debug) ls node_modules
+              working-directory: ./test-site
+              run: |
+                    ls node_modules
 
             - name: Run helper script (copy config and content)
               working-directory: ./test-site

--- a/.github/workflows/test-module-init.yml
+++ b/.github/workflows/test-module-init.yml
@@ -27,7 +27,7 @@ jobs:
               working-directory: ./test-site
               run: |
                     hugo mod init github.com/zetxek/test-site
-                    hugo mod get github.com/zetxek/adritian-free-hugo-theme
+                    hugo mod get github.com/zetxek/adritian-free-hugo-theme@9b519a5e76b0f54c96aa5e6b7af80f7201675d82
  
             - name: Download modules
               working-directory: ./test-site

--- a/.github/workflows/test-module-init.yml
+++ b/.github/workflows/test-module-init.yml
@@ -27,7 +27,7 @@ jobs:
               working-directory: ./test-site
               run: |
                     hugo mod init github.com/zetxek/test-site
-                    hugo mod get -u github.com/zetxek/adritian-free-hugo-theme@734a62b233ba386ae0326b1cb3f7323081789928
+                    hugo mod get -u github.com/zetxek/adritian-free-hugo-theme
 
             - name: Configure Hugo module in hugo.toml
               working-directory: ./test-site

--- a/.github/workflows/test-module-init.yml
+++ b/.github/workflows/test-module-init.yml
@@ -59,7 +59,7 @@ jobs:
             - name: Run helper script (copy config and content)
               working-directory: ./test-site
               run: |
-                    ./node_modules/adritian-theme-helper/dist/scripts/download-content.js
+                    ./node_modules/@zetxek/adritian-theme-helper/dist/scripts/download-content.js
 
             - name: Run build
               working-directory: ./test-site

--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ Note: the theme supports both Hugo modules and git submodules. To install the th
 1. Create a new Hugo site (this will create a new folder): `hugo new site <your website's name>`
 1. Enter the newly created folder: `cd <your website's name>/`
 1. Initialize the Hugo Module system in your site if you haven't already: `hugo mod init github.com/username/your-site` (_you don't need to host your website on GitHub, you can add anything as a name_)
+1. Install the theme as a module: `hugo mod get -u github.com/zetxek/adritian-free-hugo-theme`
+1. Install the theme helper: `hugo mod npm pack`
+1. Install the dependencies: `npm install`
+1. Run the demo content downloader: `./node_modules/adritian-theme-helper/dist/scripts/download-content.js`. This will download the demo content from the [adritian-demo](https://github.com/zetxek/adritian-demo) repository and copy it to your site, for a quick start.
+
 1. Replace the contents of your config file (`hugo.toml`) file by these: 
 
 

--- a/README.md
+++ b/README.md
@@ -38,11 +38,12 @@ You can see it live at [www.adrianmoreno.info](https://www.adrianmoreno.info) (m
 
 The dark color variation is selected automatically based on browser settings, and a color switcher is available in the footer and the mobile menu for visitors to override.
 
-You have three reference implementations of the theme provided that you can see for a demo, or to explore the source code:
+Other relevant repositories related to this theme are:
 
-1. A full-featured site, [my personal website](https://www.adrianmoreno.info) [in github too](https://github.com/zetxek/adrianmoreno.info)
-2. A simpler [demo site for the theme, adritian-demo](https://adritian-demo.vercel.app/) ([and its code](https://github.com/zetxek/adritian-demo)).
-3. The same demo site, in a [git submodules integration](https://github.com/zetxek/adritian-git-submodule-demo).
+1. [adritian-theme-helper](https://github.com/zetxek/adritian-theme-helper): npm package helper, used to bootstrap the theme. It helps initialize a site with the right content and configuration files.
+1. A full-featured site, [my personal website](https://www.adrianmoreno.info) [in github too](https://github.com/zetxek/adrianmoreno.info), so you can see how the theme can look real-life (including deployment scripts).
+1. A simpler [demo site for the theme, adritian-demo](https://adritian-demo.vercel.app/) ([and its code](https://github.com/zetxek/adritian-demo)), where the demo content comes from.
+1. The same demo site, in a [git submodules integration](https://github.com/zetxek/adritian-git-submodule-demo).
 
 💡 For more inspiration, check this document's [showcase section](#showcase).
 
@@ -70,390 +71,44 @@ The theme has been tested with Hugo version `0.136`. If you get errors regarding
 Note: the theme supports both Hugo modules and git submodules. To install the theme in the most maintainable way, you should use Hugo modules. If you prefer git submodules you can follow these [older instructions](https://gohugobrasil.netlify.app/themes/installing-and-using-themes/) or the next ones as help:
 
 <details>
-<summary>Instructions to setup the theme as a hugo module</summary>
+<summary>Step-by-step instructions to setup the theme as a hugo module</summary>
 
 1. Create a new Hugo site (this will create a new folder): `hugo new site <your website's name>`
 1. Enter the newly created folder: `cd <your website's name>/`
 1. Initialize the Hugo Module system in your site if you haven't already: `hugo mod init github.com/username/your-site` (_you don't need to host your website on GitHub, you can add anything as a name_)
 1. Install the theme as a module: `hugo mod get -u github.com/zetxek/adritian-free-hugo-theme`
-1. Install the theme helper: `hugo mod npm pack`
-1. Install the dependencies: `npm install`
-1. Run the demo content downloader: `./node_modules/adritian-theme-helper/dist/scripts/download-content.js`. This will download the demo content from the [adritian-demo](https://github.com/zetxek/adritian-demo) repository and copy it to your site, for a quick start.
-
-1. Replace the contents of your config file (`hugo.toml`) file by these: 
-
-
-<details>
-<summary>hugo.toml configuration</summary>
+1. Add the following to your `hugo.toml`, to set the theme as active: 
 
 ```
-baseURL = "<your website url>"
-languageCode = "en"
-
 [module]
-[module.hugoVersion]
-# We use hugo.Deps to list dependencies, which was added in Hugo 0.92.0
-min = "0.92.0"
-
 [[module.imports]]
-path="github.com/zetxek/adritian-free-hugo-theme"
-
-## Base mounts - so your site's assets are available
-  [[module.mounts]]
-    source = "archetypes"
-    target = "archetypes"
-
-  [[module.mounts]]
-    source = "assets"
-    target = "assets"
-
-  [[module.mounts]]
-    source = "i18n"
-    target = "i18n"
-
-  [[module.mounts]]
-    source = "layouts" 
-    target = "layouts"
-
-  [[module.mounts]]
-    source = "static"
-    target = "static"
-
-# The following mounts are required for the theme to be able to load bootstrap
-# Remember also to copy the theme's `package.json` to your site, and run `npm install`
-[[module.mounts]]
-  source = "node_modules/bootstrap/scss"
-  target = "assets/scss/bootstrap"
-
-[[module.mounts]]
-  source = "node_modules/bootstrap/dist/js"
-  target = "assets/js/bootstrap"
-
-[[module.mounts]]
-  source = "node_modules/bootstrap/dist/js/bootstrap.bundle.min.js"
-  target = "assets/js/vendor/bootstrap.bundle.min.js"
-
-## Optional, if you want print improvements (to PDF/printed)
-[[module.mounts]]
-source = "node_modules/bootstrap-print-css/css/bootstrap-print.css"
-target = "assets/css/bootstrap-print.css"
-
-[params]
-
-  title = 'Your website title'
-  description = 'Your website description'
-  sections = ["showcase", "about", "education", "experience", "client-and-work", "testimonial", "contact", "newsletter"]
-
-  # If you want to display an image logo in the header, you can add it here
-  # logo = '/img/hugo.svg'
-  homepageExperienceCount = 6
-
-  [params.analytics]
-  ## Analytics parameters.
-  ### Supported so far: Vercel (Page Insights, Analytics)
-  ### And Google (Tag Manager, Analytics)
-
-  # controls vercel page insights - disabled by default
-  # to enable, just set to true
-  vercelPageInsights = false
-  vercelAnalytics = false
-  
-  # google analytics and tag manager. to enable, set "enabled" to true
-  # and add the tracking code (UA-something for analytics, GTM-something for tag manager)
-  [params.analytics.googleAnalytics]
-      code = "UA-XXXXX-Y"
-      enabled = false
-  [params.analytics.googleTagManager]
-      code = "GTM-XXXXX"
-      enabled = false
-
-[build]
-  [build.buildStats]
-    disableClasses = false
-    disableIDs = false
-    disableTags = false
-    enable = true
-
-[params.languages.selector.disable]
-  footer = false
-
-[languages]
-  [languages.en]
-    disabled = false
-    languageCode = 'en'
-    languageDirection = 'ltr'
-    languageName = 'English'
-    title = ''
-    weight = 0
-
-    [languages.en.menus]
-      [[languages.en.menus.header]]
-        name = 'About'
-        URL = '#about'
-        weight = 2
-      [[languages.en.menus.header]]
-        name = 'Portfolio'
-        URL = '#portfolio'
-        weight = 3
-      #  [[languages.en.menus.header]]
-      #  name = "Experience"
-      #  URL = "#experience"
-      #  weight = 4
-
-      [[languages.en.menus.header]]
-        name = "Blog"
-        URL = "/blog"
-        weight = 5
-
-      [[languages.en.menus.header]]
-        name = "Contact"
-        URL = "#contact"
-        weight = 6
-
-      [[languages.en.menus.footer]]
-        name = "About"
-        URL = "#about"
-        weight = 2
-
-      [[languages.en.menus.footer]]
-        name = "Portfolio"
-        URL = "#portfolio"
-        weight = 3
-
-      [[languages.en.menus.footer]]
-        name = "Contact"
-        URL = "#contact"
-        weight = 4
-
-
-  [languages.es]
-    disabled = false
-    languageCode = 'es'
-    languageDirection = 'ltr'
-    languageName = 'Español'
-    title = ''
-    weight = 0
-      [[languages.es.menus.header]]
-        name = 'Sobre mi'
-        URL = '/es/#about'
-        weight = 2
-      [[languages.es.menus.header]]
-        name = 'Portfolio'
-        URL = '/es/#portfolio'
-        weight = 3
-
-      #  [[languages.es.menus.header]]
-      #  name = "Experiencia"
-      #  URL = "/es/#experience"
-      #  weight = 4
-
-      [[languages.es.menus.header]]
-        name = "Blog"
-        URL = "/es/blog"
-        weight = 5
-
-      [[languages.es.menus.header]]
-        name = "Contacto"
-        URL = "/es/#contact"
-        weight = 6
-
-      [[languages.es.menus.footer]]
-        name = "Sobre mi"
-        URL = "/es/#about"
-        weight = 2
-
-      [[languages.es.menus.footer]]
-        name = "Portfolio"
-        URL = "/es/#portfolio"
-        weight = 3
-
-      [[languages.es.menus.footer]]
-        name = "Contact"
-        URL = "/es/#contact"
-        weight = 4
-
-  [languages.fr]
-    disabled = false
-    languageCode = 'fr'
-    languageDirection = 'ltr'
-    languageName = 'Français'
-    title = ''
-    weight = 0
-
-    [languages.fr.menus]
-      [[languages.fr.menus.header]]
-        name = 'About'
-        URL = '#about'
-        weight = 2
-      [[languages.fr.menus.header]]
-        name = 'Portfolio'
-        URL = '#portfolio'
-        weight = 3
-      #  [[languages.fr.menus.header]]
-      #  name = "Experience"
-      #  URL = "#experience"
-      #  weight = 4
-
-      [[languages.fr.menus.header]]
-        name = "Blog"
-        URL = "/blog"
-        weight = 5
-
-      [[languages.fr.menus.header]]
-        name = "Contact"
-        URL = "#contact"
-        weight = 6
-
-      [[languages.fr.menus.footer]]
-        name = "About"
-        URL = "#about"
-        weight = 2
-
-      [[languages.fr.menus.footer]]
-        name = "Portfolio"
-        URL = "#portfolio"
-        weight = 3
-
-      [[languages.fr.menus.footer]]
-        name = "Contact"
-        URL = "#contact"
-        weight = 4
-
-# Plugins
-[params.plugins]
-
-  # CSS Plugins
-  [[params.plugins.css]]
-  URL = "css/custom.css"
-  [[params.plugins.css]]
-  URL = "css/adritian-icons.css"
-  ## Optional, if you want print improvements (to PDF/printed)
-  [[params.plugins.css]]
-  URL = "css/bootstrap-print.css"
-  
-  # JS Plugins
-  [[params.plugins.js]]
-  URL = "js/rad-animations.js"
-  [[params.plugins.js]]
-  URL = "js/sticky-header.js"
-  [[params.plugins.js]]
-  URL = "js/library/fontfaceobserver.js"
-
-  # SCSS Plugins
-  [[params.plugins.scss]]
-  URL = "scss/adritian.scss"
-
-
-# theme/color style 
-[params.colorTheme]
-
-## the following configuration would disable automatic theme selection
-#  [params.colorTheme.auto]
-#    disable = true
-#  [params.colorTheme.forced]
-#    theme = "dark"
-
-## the following parameter will disable theme override in the footer
-#  [params.colorTheme.selector.disable]
-#  footer = true
-
-
-## by default we allow override AND automatic selection
-
-[params.blog]
-layout = "default" # options: default, sidebar
-sidebarWidth = "25" # percentage width of the sidebar
-showCategories = true
-showRecentPosts = true
-recentPostCount = 5
-listStyle = "summary" # options: simple, summary
+path = "github.com/zetxek/adritian-free-hugo-theme"
 ```
+
+1. Prepare the `package.json` file: `hugo mod npm pack`
+1. Install the dependencies: `npm install`. This will include Bootstrap (needed for styling) and the helper script [adritian-theme-helper](https://github.com/zetxek/adritian-theme-helper). 
+1. Run the initial content downloader: `./node_modules/adritian-theme-helper/dist/scripts/download-content.js`. This will download the demo content from the [adritian-demo](https://github.com/zetxek/adritian-demo) repository and copy it to your site, for a quick start (including translations, images, configuration and content)
 </details>
 
-This configuration allows you to have a base to edit and adapt to your site, and see the available functionalities.
-Make sure to edit `baseURL`, `title` and `description`. You can edit the header links, as well as the languages to your needs.
 
-1. Get the module: `hugo mod get -u`
-1. Execute `hugo mod npm pack` - this will generate a `package.json` file in the root folder of your site, with the dependencies for the theme.
-1. Execute `npm install` - this will install the dependencies for the theme (including bootstrap)
-1. (Optional, to override the defaults) Create a file `data/homepage.yml` with the contents of the [`exampleSite/data/homepage.yml`](https://github.com/zetxek/adritian-free-hugo-theme/blob/main/exampleSite/data/homepage.yml) file, and customize to your needs (__note: this file is not included in your theme if you use hugo modules, download it manually from the repository__)
+### Running the site
+
+The initial configuration allows you to have a base to edit and adapt to your site, and see the available functionalities.
+**Make sure to edit `baseURL`, `title` and `description`**. You can edit the header links, as well as the languages to your needs.
+
+After you have installed the `npm` packages and setup the initial contents, you can
+
 1. Start Hugo with `hugo server`...
 1. 🎉 The theme is alive on http://localhost:1313/
 
-</details>
+For next steps and guidance on where to customize your content, [check the demo site](https://adritian-demo.vercel.app/). 
+For other installation methods (as submodule, or manual configuration) you can check the demo site help page. 
 
+### Additional features and configuration
 
-### Traditional Installation (as git submodule)
+The theme is extensible and customizable in multiple areas, and it can be tricky to figure what to exactly edit. This is a guide (that is complemented by the [demo site](https://adritian-demo.vercel.app/)).
 
-If you prefer not to use Hugo Modules, you can still install the theme as a git submodule.
-The guide is very similar to [official "Quick Start"](https://gohugo.io/getting-started/quick-start/#create-a-site), just changing the theme URL in the `git submodule add` command: 
-
-<details>
-<summary>Old instructions for git submodules</summary>
-
-- Create a new Hugo site (this will create a new folder): `hugo new site <your website's name>`
-- Enter the newly created folder: `cd <your website's name>/`
-- Initialize hugo modules: `hugo mod init github.com/<your_user>/<your_project>`
-- Install PostCSS: execute `npm i -D postcss postcss-cli autoprefixer` from the top-level site folder [check [Hugo's official docs](https://gohugo.io/hugo-pipes/postcss/)].
-- Add adritian-free-hugo-theme as a module dependency, by adding
-  ```
-  [module]
-  [[module.imports]]
-    path = 'github.com/zetxek/adritian-free-hugo-theme'
-  ```
-  To your `hugo.toml` file, and executing `hugo mod get -u`
-  
-- Replace the `hugo.toml` file in the project's root directory with the contents of [themes/adritian-free-hugo-theme/exampleSite/config.toml](https://github.com/zetxek/adritian-free-hugo-theme/blob/main/exampleSite/hugo.toml). If you are using the git submodules, you can execute `cp themes/adritian-free-hugo-theme/exampleSite/hugo.toml hugo.toml` (*executed from the website root folder*), otherwise just copy and paste the contents.
-- Create the file `data/homepage.yml`, with the initial contents of the [`exampleSite/data/homepage.yml`](https://github.com/zetxek/adritian-free-hugo-theme/blob/main/exampleSite/data/homepage.yml). This will serve as your starting point to customize your home content ✍️
-- Start Hugo with `hugo server -D`
-- 🎉 The theme is alive on http://localhost:1313/
-
-
-_Optional, and only for git submodule or when you download the whole repo:_
-if you want to preview the theme with the example content before deciding if it's what you are looking for, you can run the theme with the example content:
-```
-cd themes/adritian-free-hugo-theme/exampleSite
-hugo server --themesDir ../..
-```
-
-Note: The `exampleSite` is not downloaded when installing the Hugo module. That's why this works only as git submodule or full repo download. 
-</details>
-
-
----
-
-After this, you can start adding your own content to the site, and customize the configuration.
-
-If everything has gone well asn you have the right configuration, the output for the `serve` command will be something like this:
-<details>
-<summary>Example output for the serve command</summary>
-
-```
-adritian-demo git:(master) ✗ hugo server -D
-Watching for changes in /Users/adrianmorenopena/tmp/theme-test/themes/adritian-free-hugo-theme/{archetypes,assets,data,exampleSite,i18n,layouts,static}
-Watching for config changes in /Users/adrianmorenopena/tmp/theme-test/themes/adritian-free-hugo-theme/exampleSite/hugo.toml
-Start building sites …
-hugo v0.136.2+extended darwin/arm64 BuildDate=2024-10-17T14:30:05Z VendorInfo=brew
-
-
-                   | EN | ES | FR
--------------------+----+----+-----
-  Pages            | 24 | 10 |  8
-  Paginator pages  |  0 |  0 |  0
-  Non-page files   |  0 |  0 |  0
-  Static files     | 90 | 90 | 90
-  Processed images | 24 |  0 |  0
-  Aliases          |  1 |  0 |  0
-  Cleaned          |  0 |  0 |  0
-
-Built in 1788 ms
-Environment: "development"
-Serving pages from disk
-Running in Fast Render Mode. For full rebuilds on change: hugo server --disableFastRender
-Web Server is available at http://localhost:1313/ (bind address 127.0.0.1)
-Press Ctrl+C to stop
-```
-</details>
+<img width="1395" alt="image" src="https://github.com/user-attachments/assets/270c4445-5354-441a-ab23-21d91762e33c" />
 
 #### Multi-language support
 
@@ -467,16 +122,11 @@ You can add additional languages, or disable the provided ones (by setting `disa
 
 The introduction of i18n support was done in the version `v1.3.0` and it has breaking changes due to the way in which the content was managed. You can read about the upgrade path in [UPGRADING.md](UPGRADING.md).
 
-
-#### Additional configuration
-
-<img width="1395" alt="image" src="https://github.com/user-attachments/assets/270c4445-5354-441a-ab23-21d91762e33c" />
-
-##### Editing the theme content
+#### Editing the theme content
 
 You can check the repository [adritian-demo](https://github.com/zetxek/adritian-demo) for a reference implementation, as well as the [theme website](https://adritian-demo.vercel.app/) (https://adritian-demo.vercel.app/), to get a visual guide on how to edit the content. 
 
-##### Shortcodes
+#### Shortcodes
 
 The theme has two shortcodes available for use in the content:
 
@@ -485,10 +135,10 @@ The theme has two shortcodes available for use in the content:
 
 You can see them in effect in the [demo site CV page](https://adritian-demo.vercel.app/cv). 
 
-##### Contact form
+#### Contact form
 _(optional, if you want to use the contact form)_ edit the key `contact` in your `homepage.yml` file, to customize your mail address. Sign up in [formspree](https://formspree.io) to redirect mails to your own.
 
-##### Blog
+#### Blog
 
 Two layouts are available for the blog:
 - `default` (full-width for posts)
@@ -512,7 +162,7 @@ The posts will be markdown files stored in the `content/blog` folder.
 
 The layout can be configured in the `hugo.toml` file, under the `[params.blog]` section.
 
-##### Experience
+#### (Job) Experience
 
 This functionality and content is especially suited for personal professional sites, showcasing the work experience: 
 
@@ -565,7 +215,7 @@ Make sure that you have the dependencies installed. Check the troubleshooting st
 
 - The site renders in a weird-looking way, or you miss content. Check that the content of your site's config file (`hugo.toml`) contain what is mentioned [in the guide](https://github.com/zetxek/adritian-free-hugo-theme?tab=readme-ov-file#as-a-hugo-module-recommended), especially the `mount` sections. 
 
-## Getting help
+### Getting help
 
 The project is offered "as is", and it's a side project that powers my personal website. Support is given whenever life allows, and it's not offered in private e-mails: please use the public issue trackers in GitHub so others benefit from the conversation.
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -2,6 +2,21 @@
 
 This documentation is meant to help you upgrade across versions, when potentially breaking changes are introduced.
 
+## v1.6.0
+
+This version introduces the usage of [@zetxek/adritian-theme-helper](https://www.npmjs.com/package/adritian-theme-helper) to help initialize a site with the theme. This is not of much use to existing setups - but good to know.
+
+Additionally, there are a number of [changes in HTML structure](https://github.com/zetxek/adritian-free-hugo-theme/pull/217/files) to ensure that the content is valid, including class renaming and change of element types.
+
+Some of the changes are listed here in a an attempt to help you edit your custom CSS in case you depended on it:
+
+- Prevent `p.lead` usage, preferring `div.lead` instead. This is done to prevent nested `<p>` elements or broken paragraphs, using a wrapping `div` instead.
+- Fixed nested `main` elements in the `/blog` page, using instead `<main><div#main-content>`. 
+- Prevented duplicated usage of the `#experience` id, by renaming it to `#experience-single` in `layouts/partials/experience.html` and `#experience-list` in `layouts/shortcodes/experience-list.html`.
+- Removed wrapping `<p>` element in `layouts/partials/testimonial.html`.
+
+I hope this doesn't cause too much trouble in your existing sites - and allows for a smooth transition to `v1.6.0` 🤞
+
 ## v1.5.12
 
 The options to control how the language and theme selectors are displayed in the header and footer have been refactored, to enable control over each placement individually (footer and header).

--- a/assets/scss/adritian.scss
+++ b/assets/scss/adritian.scss
@@ -112,6 +112,9 @@ p + p {
         font-size: 60px;
     }
 }
+.lead{
+    margin-bottom: 1rem;
+}
 .lead a,
 p a,
 span a {

--- a/assets/scss/adritian.scss
+++ b/assets/scss/adritian.scss
@@ -112,6 +112,7 @@ p + p {
         font-size: 60px;
     }
 }
+.lead a,
 p a,
 span a {
     color: #000;
@@ -120,6 +121,7 @@ span a {
     border-bottom: 1px solid rgba(0, 0, 0, 0.5);
     transition: all 0.5s;
 }
+.lead a:hover,
 p a:hover,
 span a:hover {
     color: #478079;
@@ -283,7 +285,7 @@ footer_links .nav-item .nav-link::after {
     .lead{
         color: #fff !important;
     }
-    p a, span a{
+    .lead a, p a, span a{
         color: #fff !important;
     }
     p{

--- a/data/homepage.yml
+++ b/data/homepage.yml
@@ -61,6 +61,9 @@ showcase:
 
     - icon: "cloud-arrow-down"
       URL: "https://www.adrianmoreno.info/"
+
+    - icon: "square-xing"
+      URL: "https://www.adrianmoreno.info/"
 # about
 about:
   enable: true
@@ -115,10 +118,14 @@ testimonial:
 contact:
   enable: true
   form:
-    action: "#"
+    action: "/"
+    method: "GET"
   button:
     icon: "icon-email"
 
 # newsletter
 newsletter:
   enable: true
+  form:
+    action: "/"
+    method: "GET"

--- a/exampleSite/data/homepage.yml
+++ b/exampleSite/data/homepage.yml
@@ -118,10 +118,14 @@ testimonial:
 contact:
   enable: true
   form:
-    action: "#"
+    action: "/"
+    method: "GET"
   button:
     icon: "icon-email"
 
 # newsletter
 newsletter:
   enable: true
+  form:
+    action: "/"
+    method: "GET"

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -106,7 +106,7 @@
   translation:  '<p class="lead">
       Here you can add some information about you. A small excerpt that describes 
       your experience, for example.   
-      </br>
+      <br/>
       You explain something about your academic/study background, as well as your
       preferred areas of work.
       </p>

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -1,5 +1,5 @@
   {{ define "main" }}
-  <main id="main-content" class="blog flex-grow-1">
+  <div id="main-content" class="blog flex-grow-1">
     <div class="container section">
       <div class="row {{ if eq .Site.Params.blog.layout "sidebar" }}has-sidebar{{ end }}">
         {{ if eq .Site.Params.blog.layout "sidebar" }}
@@ -21,5 +21,5 @@
         </div>
       </div>
     </div>
-  </main>
+  </div>
   {{ end }}

--- a/layouts/partials/client-and-work.html
+++ b/layouts/partials/client-and-work.html
@@ -60,9 +60,9 @@
       {{ if $is_even }}
       <div class="col-12 col-md-5 mt-4 mt-md-0 my-md-auto even">
         <h3>{{ .Params.title }}</h3>
-        <p class="lead">
+        <div class="lead">
           {{ .Page.Content }}
-        </p>
+        </div>
         <a href="{{ .Params.button.URL | absURL }}" class="btn btn-primary"
           >{{ .Params.button.btnText }}<i class="{{ .Params.button.icon }}"></i
         ></a>
@@ -116,9 +116,9 @@
       </div>
       <div class="col-12 col-md-5 mt-4 mt-md-0 my-md-auto">
         <h3>{{ .Params.title }}</h3>
-        <p class="lead">
+        <div class="lead">
           {{ .Page.Content }}
-        </p>
+        </div>
         <a href="{{ .Params.button.URL | absURL }}" class="btn btn-primary"
           >{{ .Params.button.btnText }}<i class="{{ .Params.button.icon }}"></i
         ></a>

--- a/layouts/partials/experience.html
+++ b/layouts/partials/experience.html
@@ -1,5 +1,5 @@
 {{ if .Site.Data.homepage.experience.enable }}
-<section id="experience" class="container section-experience section section--border-bottom rad-animation-group flex-grow-1">
+<section id="experience-single" class="container section-experience section section--border-bottom rad-animation-group flex-grow-1">
         <div class="row flex-column-reverse flex-md-row rad-fade-down">
             <div class="experience-list col-12 cold-md-12 col-sm-6 mt-5 mt-sm-0">
                 {{ $baseLangSite := .Sites.Default }}

--- a/layouts/partials/newsletter.html
+++ b/layouts/partials/newsletter.html
@@ -5,7 +5,9 @@
     <div class="col-12 text-center">
       <h2>{{ i18n "newsletter_title" }}</h2>
       <div class="rad-subscription-group">
-        <form id="rad-subscription" action="">
+        <form id="rad-subscription"
+          action="{{ .Site.Data.homepage.newsletter.form.action }}" 
+          method="{{ .Site.Data.homepage.newsletter.form.method }}" >
           <input
             id="rad-subscription-email"
             type="email"

--- a/layouts/partials/showcase.html
+++ b/layouts/partials/showcase.html
@@ -8,9 +8,9 @@
           <br />
           <span>{{ i18n "showcase_subtitle" }}</span>
         </h1>
-        <p class="lead">
+        <div class="lead">
           {{ i18n "showcase_description" | safeHTML }}
-        </p>
+        </div>
         <a
           href="{{ .Site.Data.homepage.showcase.button.URL }}"
           class="btn btn-primary"

--- a/layouts/partials/testimonial.html
+++ b/layouts/partials/testimonial.html
@@ -11,9 +11,7 @@
 
             <div class="col-12 col-md-4 mb-5 mb-md-0 testimonial container">
                 <i class="icon-quote-left"></i>
-                <p>
-                    {{ .Content }}
-                </p>
+                {{ .Content }}
                 <div class="testimonial__author row gx-0">
                          {{ $img := resources.Get .Params.image.x }}
                          {{ $img2x := resources.Get .Params.image._2x }}

--- a/layouts/shortcodes/experience-list.html
+++ b/layouts/shortcodes/experience-list.html
@@ -1,4 +1,4 @@
-<section id="experience" class="section-experience section section--border-bottom rad-animation-group flex-grow-1">
+<section id="experience-list" class="section-experience section section--border-bottom rad-animation-group flex-grow-1">
     <div class="row flex-column-reverse flex-md-row rad-fade-down">
         <div class="experience-list col-12 mt-5 mt-sm-0">
             {{ $xp := (where .Site.RegularPages.ByDate "Type" "experience") }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "devDependencies": {
         "@playwright/test": "^1.49.1",
         "@types/node": "^22.10.5",
-        "adritian-theme-helper": "^1.0.1",
+        "@zetxek/adritian-theme-helper": "^1.0.3",
         "autoprefixer": "^10.4.17",
         "bootstrap": "^5.3.3",
         "npm-run-all": "^4.1.5",
@@ -104,10 +104,10 @@
         "undici-types": "~6.20.0"
       }
     },
-    "node_modules/adritian-theme-helper": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/adritian-theme-helper/-/adritian-theme-helper-1.0.1.tgz",
-      "integrity": "sha512-ZQVxHrSVd4Cov+nYt9Ctt/wGjH7DIVKPYNl6bHo+b6sbJ3OwEwe9xGphyrtiEJRW+x8prIJyyivrV3SoxP/6ig==",
+    "node_modules/@zetxek/adritian-theme-helper": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@zetxek/adritian-theme-helper/-/adritian-theme-helper-1.0.3.tgz",
+      "integrity": "sha512-GPaZMpgVrrIBxEOcXIUWfyZ2S9PFW2do/cCFQFFphTl/Dv/TM8sCr/YKV+LVZp0JHAfGKlNOvnRkgt5puNmp7w==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
       "devDependencies": {
         "@playwright/test": "^1.49.1",
         "@types/node": "^22.10.5",
+        "adritian-theme-helper": "^1.0.1",
         "autoprefixer": "^10.4.17",
         "bootstrap": "^5.3.3",
         "npm-run-all": "^4.1.5",
@@ -101,6 +102,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.20.0"
+      }
+    },
+    "node_modules/adritian-theme-helper": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/adritian-theme-helper/-/adritian-theme-helper-1.0.1.tgz",
+      "integrity": "sha512-ZQVxHrSVd4Cov+nYt9Ctt/wGjH7DIVKPYNl6bHo+b6sbJ3OwEwe9xGphyrtiEJRW+x8prIJyyivrV3SoxP/6ig==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "adritian-download-content": "dist/scripts/download-content.js"
       }
     },
     "node_modules/ansi-regex": {

--- a/package.hugo.json
+++ b/package.hugo.json
@@ -4,6 +4,7 @@
     "bootstrap-print-css": "^1.0.0",
     "autoprefixer": "^10.4.17",
     "postcss": "^8.4.35",
-    "postcss-cli": "^11.0.0"
+    "postcss-cli": "^11.0.0",
+    "adritian-theme-helper": "^1.0.1"
   }
 }

--- a/package.hugo.json
+++ b/package.hugo.json
@@ -5,6 +5,6 @@
     "autoprefixer": "^10.4.17",
     "postcss": "^8.4.35",
     "postcss-cli": "^11.0.0",
-    "adritian-theme-helper": "^1.0.3"
+    "@zetxek/adritian-theme-helper": "^1.0.3"
   }
 }

--- a/package.hugo.json
+++ b/package.hugo.json
@@ -5,6 +5,6 @@
     "autoprefixer": "^10.4.17",
     "postcss": "^8.4.35",
     "postcss-cli": "^11.0.0",
-    "adritian-theme-helper": "^1.0.1"
+    "adritian-theme-helper": "^1.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.35",
     "postcss-cli": "^11.0.0",
-    "adritian-theme-helper": "^1.0.1"
+    "adritian-theme-helper": "^1.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "bootstrap": "^5.3.3",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.35",
-    "postcss-cli": "^11.0.0"
+    "postcss-cli": "^11.0.0",
+    "adritian-theme-helper": "^1.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.35",
     "postcss-cli": "^11.0.0",
-    "adritian-theme-helper": "^1.0.3"
+    "@zetxek/adritian-theme-helper": "^1.0.3"
   }
 }


### PR DESCRIPTION
As discussed in numerous issues and https://github.com/zetxek/adritian-free-hugo-theme/discussions/191, the initial setup of the theme is convoluted. This PR introduces a helper script (hosted at https://github.com/zetxek/adritian-theme-helper) and distributed as npm package, that automates some of the currently manual tasks.

The script is downloaded via the `package.hugo.json` file, that was introduced in https://github.com/zetxek/adritian-free-hugo-theme/pull/173. 


The downloaded files by the helper script include:

- configuration (`hugo.toml`, `data/homepage.yml`)
- content (`content/*`)
- assets (`assets/*` and `static/*`)
- i18n files (`i18n/*`)

The script can be extended for additional steps after this PR is merged and released 🚀 


The pipeline `test-module-init` (https://github.com/zetxek/adritian-free-hugo-theme/actions/workflows/test-module-init.yml) includes a test for the helper script, as before running the HTML validation it downloads the content and config from the demo repo 🪄 

- [x] fix HTML validation errors that arise
- [x] modify CI/CD script to use `package.hugo.json` file
- [x]  add test to CI/CD to verify that the helper script works
- [x] update instructions in README
- [x] update UPGRADING.md to document potentially breaking CSS changes (in case that custom CSS depended on them)