### PR TITLE
Increase padding-top for .rad-showcase in _raditian.scss to enhance content on larger screens

### DIFF
--- a/assets/scss/_raditian.scss
+++ b/assets/scss/_raditian.scss
@@ -1498,7 +1498,7 @@ aside.content-browser{
 
 @media only screen and (min-width : 992px) {    
     .rad-showcase{
-        padding-top: 40px;
+        padding-top: 120px;
     }    
 }
 


### PR DESCRIPTION
Fixes #215.

Short text:
<img width="1446" alt="SCR-20250215-sepj" src="https://github.com/user-attachments/assets/bbaee949-5225-43a9-8798-1271b69fbe86" />

Longer text:
<img width="1444" alt="SCR-20250215-seqq" src="https://github.com/user-attachments/assets/2fc337bd-b01a-42cd-8d3c-2a4ed258fbd7" />
