### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ path = "github.com/zetxek/adritian-free-hugo-theme"
 
 1. Prepare the `package.json` file: `hugo mod npm pack`
 1. Install the dependencies: `npm install`. This will include Bootstrap (needed for styling) and the helper script [adritian-theme-helper](https://github.com/zetxek/adritian-theme-helper). 
-1. Run the initial content downloader: `./node_modules/adritian-theme-helper/dist/scripts/download-content.js`. This will download the demo content from the [adritian-demo](https://github.com/zetxek/adritian-demo) repository and copy it to your site, for a quick start (including translations, images, configuration and content)
+1. Run the initial content downloader: `./node_modules/@zetxek/adritian-theme-helper/dist/scripts/download-content.js`. This will download the demo content from the [adritian-demo](https://github.com/zetxek/adritian-demo) repository and copy it to your site, for a quick start (including translations, images, configuration and content)
 </details>
 
 


### PR DESCRIPTION
Fixes #225.
Fixing the path for the adritian-theme-helper command.
The test was already correct: https://github.com/zetxek/adritian-free-hugo-theme/blob/dec6ea7b7131e95ecabf42e8d1c6aa652e3d55e6/.github/workflows/test-module-init.yml#L59-L63

The command was wrong, same as in https://github.com/zetxek/adritian-theme-helper/issues/1.