### PR TITLE
Fix html validation 

### DIFF
--- a/.github/workflows/test-module-init.yml
+++ b/.github/workflows/test-module-init.yml
@@ -13,7 +13,7 @@ jobs:
             - uses: actions/checkout@v4
 
             - name: Setup Hugo
-              uses: peaceiris/actions-hugo@v2
+              uses: peaceiris/actions-hugo@v3
               with:
                 hugo-version: 'latest'
                 extended: true
@@ -35,6 +35,31 @@ jobs:
                     echo '[module]
                     [[module.imports]]
                     path = "github.com/zetxek/adritian-free-hugo-theme"' > hugo.toml
+            
+            - name: Upload test site
+              uses: actions/upload-artifact@v3
+              with:
+                name: test-site
+                path: test-site
+                retention-days: 1
+
+    build-site:
+        needs: test-module-init
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            
+            - name: Setup Hugo
+              uses: peaceiris/actions-hugo@v3
+              with:
+                hugo-version: 'latest'
+                extended: true
+                
+            - name: Download test site
+              uses: actions/download-artifact@v3
+              with:
+                name: test-site
+                path: test-site
 
             - name: Pack dependencies
               working-directory: ./test-site
@@ -65,8 +90,25 @@ jobs:
               working-directory: ./test-site
               run: hugo
 
+            - name: Upload built site
+              uses: actions/upload-artifact@v3
+              with:
+                name: built-site
+                path: test-site/public
+                retention-days: 1
+
+    validate-html:
+        needs: build-site
+        runs-on: ubuntu-latest
+        steps:
+            - name: Download built site
+              uses: actions/download-artifact@v3
+              with:
+                name: built-site
+                path: ./public
+
             - name: Print index.html
-              working-directory: ./test-site/public
+              working-directory: ./public
               run: |
                     cat index.html
 
@@ -74,4 +116,4 @@ jobs:
             - name: Validate HTML syntax
               uses: Cyb3r-Jak3/html5validator-action@v7.2.0
               with:
-                root: ./test-site/public
+                root: ./public

--- a/.github/workflows/test-module-init.yml
+++ b/.github/workflows/test-module-init.yml
@@ -37,7 +37,7 @@ jobs:
                     path = "github.com/zetxek/adritian-free-hugo-theme"' > hugo.toml
             
             - name: Upload test site
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
                 name: test-site
                 path: test-site
@@ -56,7 +56,7 @@ jobs:
                 extended: true
                 
             - name: Download test site
-              uses: actions/download-artifact@v3
+              uses: actions/download-artifact@v4
               with:
                 name: test-site
                 path: test-site
@@ -91,7 +91,7 @@ jobs:
               run: hugo
 
             - name: Upload built site
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
                 name: built-site
                 path: test-site/public
@@ -102,7 +102,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Download built site
-              uses: actions/download-artifact@v3
+              uses: actions/download-artifact@v4
               with:
                 name: built-site
                 path: ./public

--- a/.github/workflows/test-module-init.yml
+++ b/.github/workflows/test-module-init.yml
@@ -29,12 +29,25 @@ jobs:
                     hugo mod init github.com/zetxek/test-site
                     hugo mod get -u github.com/zetxek/adritian-free-hugo-theme
 
+            - name: Configure module ref
+              if: github.ref != 'refs/heads/main'
+              working-directory: ./test-site
+              run: |
+                hugo mod get -u github.com/zetxek/adritian-free-hugo-theme@${{ github.ref }}
+
             - name: Configure Hugo module in hugo.toml
               working-directory: ./test-site
               run: |
-                    echo '[module]
-                    [[module.imports]]
-                    path = "github.com/zetxek/adritian-free-hugo-theme"' > hugo.toml
+                echo '[module]
+                [[module.imports]]
+                path = "github.com/zetxek/adritian-free-hugo-theme"' > hugo.toml
+            
+            - name: Validate Hugo module configuration
+              working-directory: ./test-site
+              run: |
+                hugo mod verify
+                hugo mod graph
+                
             
             - name: Upload test site
               uses: actions/upload-artifact@v4

--- a/.github/workflows/test-module-init.yml
+++ b/.github/workflows/test-module-init.yml
@@ -117,3 +117,4 @@ jobs:
               uses: Cyb3r-Jak3/html5validator-action@v7.2.0
               with:
                 root: ./public
+                skip_git_check: true

--- a/.github/workflows/test-module-init.yml
+++ b/.github/workflows/test-module-init.yml
@@ -33,7 +33,10 @@ jobs:
               if: github.ref != 'refs/heads/main'
               working-directory: ./test-site
               run: |
-                hugo mod get -u github.com/zetxek/adritian-free-hugo-theme@${{ github.sha }}
+                # Use the branch that initiated the PR
+                branch_name=${GITHUB_HEAD_REF}
+                echo "Using branch: ${branch_name}"
+                hugo mod get -u github.com/zetxek/adritian-free-hugo-theme@${branch_name}
 
             - name: Configure Hugo module in hugo.toml
               working-directory: ./test-site

--- a/.github/workflows/test-module-init.yml
+++ b/.github/workflows/test-module-init.yml
@@ -33,7 +33,7 @@ jobs:
               if: github.ref != 'refs/heads/main'
               working-directory: ./test-site
               run: |
-                hugo mod get -u github.com/zetxek/adritian-free-hugo-theme@${{ github.ref }}
+                hugo mod get -u github.com/zetxek/adritian-free-hugo-theme@${{ github.sha }}
 
             - name: Configure Hugo module in hugo.toml
               working-directory: ./test-site

--- a/exampleSite/content/home/home.es.md
+++ b/exampleSite/content/home/home.es.md
@@ -61,7 +61,6 @@ draft = false
     button2_text="Otro Botón (2)"
     button3_text="Ver todo"
     button3_url="/es/experience"
-    social_links="aaa"
 >}}
 ## Experiencia (lista)
 

--- a/exampleSite/content/home/home.es.md
+++ b/exampleSite/content/home/home.es.md
@@ -81,7 +81,7 @@ draft = false
     contact_form_message="Tu mensaje"
     contact_button="Enviar mensaje"
     contact_phone_title="Mi teléfono"
-    contact_phone_number="<a href='tel:+555 666 777'>555 666 777</a>"
+    contact_phone_number="<a href='tel:+555666777'>555 666 777</a>"
     contact_email_title="Mi correo"
     contact_email_email="demo@demosite.com"
     contact_address_title="Mi ubicación"

--- a/exampleSite/content/home/home.es.md
+++ b/exampleSite/content/home/home.es.md
@@ -39,7 +39,7 @@ draft = false
 
 {{< about-section
     title="Sobre mí"
-    content="Usando delimitadores HTML <code><></code>"
+    content="Usando <code>sintaxis HTML</code>"
     about_button="Texto del botón"
     button_icon="info"
     button_text="Puedes editar esto"
@@ -62,9 +62,11 @@ draft = false
     button3_text="Ver todo"
     button3_url="/es/experience"
 >}}
+
+
 ## Experiencia (lista)
 
-{{< experience-list >}}
+Puedes ver una versión alternativa, usando `experience-list` en [/cv](/cv).
  
 
 {{< client-and-work-section
@@ -84,7 +86,10 @@ draft = false
     contact_email_title="Mi correo"
     contact_email_email="demo@demosite.com"
     contact_address_title="Mi ubicación"
-    contact_address_address="🇩🇰 Dinamarca" >}}
+    contact_address_address="🇩🇰 Dinamarca"
+    form_action="/"
+    form_method="POST"
+     >}}
 
 {{< newsletter-section 
     newsletter_title="Mantente actualizado"
@@ -93,19 +98,6 @@ draft = false
     newsletter_success_message="¡Gracias por suscribirte!"
     newsletter_error_message="Algo salió mal, por favor inténtalo de nuevo."
     newsletter_note="Respetamos tu privacidad y no compartiremos tus datos."
+    form_action="/"
+    form_method="POST"
 >}}
-
-Additional content added after the `section` blocks:
-
-```
-sections = [
-  "showcase",
-  "about",
-  "education",
-  "experience",
-  "client-and-work",
-  "testimonial",
-  "contact",
-  "newsletter",
-]
-```

--- a/exampleSite/content/home/home.fr.md
+++ b/exampleSite/content/home/home.fr.md
@@ -81,7 +81,7 @@ draft = false
     contact_form_message="Votre message"
     contact_button="Envoyer le message"
     contact_phone_title="Mon téléphone"
-    contact_phone_number="<a href='tel:+555 666 777'>555 666 777</a>"
+    contact_phone_number="<a href='tel:+555666777'>555 666 777</a>"
     contact_email_title="Mon e-mail"
     contact_email_email="demo@demosite.com"
     contact_address_title="Ma localisation"

--- a/exampleSite/content/home/home.fr.md
+++ b/exampleSite/content/home/home.fr.md
@@ -1,52 +1,51 @@
 +++
-title =  "Accueil"
+title = "Accueil"
 type = "home"
 draft = false
 +++
 
-
 {{< showcase-section
-    title="Section en vedette"
-    subtitle="Sous-titre - provenant de <code>home.md</code>"
-    buttonText="E-mail"
-    description="Texte en <strong>gras</strong> et normal. Ceci provient de <code>home.md</code>. Non fourni ? utilise i18n par défaut (pour l'instant, pour offrir la compatibilité avec les versions >1.7.0)"
+    title="Section vedette"
+    subtitle="Sous-titre - vient de <code>home.md</code>"
+    buttonText="Courriel"
+    description="Texte en <strong>gras</strong> et normal. Ceci provient de <code>home.md</code>. Non fourni ? i18n par défaut (pour compatibilité versions >1.7.0)"
     image="images/showcase/showcase.png"
     image2x="images/showcase/showcase@2x.png"
- >}}
+>}}
 
-    {{< platform-links >}}
-        {{< link icon="square-facebook" url="https://facebook.com/yourpage" >}}
-        {{< link icon="square-twitter" url="https://twitter.com/yourpage" >}}
-        {{< link icon="linkedin" url="https://www.linkedin.com/in/adrianmoreno/" >}}
-        {{< link icon="square-github" url="https://github.com/zetxek" >}}
-        {{< link icon="x-twitter" url="https://twitter.com/zetxek" >}}
-        {{< link icon="dribbble" url="#" >}}
-        {{< link icon="behance" url="#" >}}
-        {{< link icon="youtube" url="#" >}}
-        {{< link icon="instagram" url="https://www.instagram.com/zetxek/" >}}
-        {{< link icon="square-facebook" url="https://www.facebook.com/zetxek/" >}}
-        {{< link icon="codepen" url="#" >}}
-        {{< link icon="yelp" url="https://www.yelp.com/" >}}
-        {{< link icon="bluesky" url="https://www.bluesky.com/" >}}
-        {{< link icon="threads" url="https://www.threads.net/" >}}
-        {{< link icon="face-smile" url="https://www.adrianmoreno.info/" >}}
-        {{< link icon="user" url="https://www.adrianmoreno.info/" >}}
-        {{< link icon="quote-left" url="https://www.adrianmoreno.info/" >}}
-        {{< link icon="cloud-arrow-down" url="https://www.adrianmoreno.info/" >}}
-        {{< link icon="square-xing" url="https://www.adrianmoreno.info/" >}}
-    {{< /platform-links >}}
+{{< platform-links >}}
+    {{< link icon="square-facebook" url="https://facebook.com/yourpage" >}}
+    {{< link icon="square-twitter" url="https://twitter.com/yourpage" >}}
+    {{< link icon="linkedin" url="https://www.linkedin.com/in/adrianmoreno/" >}}
+    {{< link icon="square-github" url="https://github.com/zetxek" >}}
+    {{< link icon="x-twitter" url="https://twitter.com/zetxek" >}}
+    {{< link icon="dribbble" url="#" >}}
+    {{< link icon="behance" url="#" >}}
+    {{< link icon="youtube" url="#" >}}
+    {{< link icon="instagram" url="https://www.instagram.com/zetxek/" >}}
+    {{< link icon="square-facebook" url="https://www.facebook.com/zetxek/" >}}
+    {{< link icon="codepen" url="#" >}}
+    {{< link icon="yelp" url="https://www.yelp.com/" >}}
+    {{< link icon="bluesky" url="https://www.bluesky.com/" >}}
+    {{< link icon="threads" url="https://www.threads.net/" >}}
+    {{< link icon="face-smile" url="https://www.adrianmoreno.info/" >}}
+    {{< link icon="user" url="https://www.adrianmoreno.info/" >}}
+    {{< link icon="quote-left" url="https://www.adrianmoreno.info/" >}}
+    {{< link icon="cloud-arrow-down" url="https://www.adrianmoreno.info/" >}}
+    {{< link icon="square-xing" url="https://www.adrianmoreno.info/" >}}
+{{< /platform-links >}}
 {{< /showcase-section >}}
 
 {{< about-section
     title="À propos de moi"
-    content="Utilisation des délimiteurs HTML <code><></code>"
+    content="En utilisant la <code>syntaxe HTML</code>"
     about_button="Texte du bouton"
     button_icon="info"
     button_text="Vous pouvez modifier ceci"
     button_url="https://www.google.com"
     image="images/about/user-picture.png"
     image2x="images/about/user-picture@2x.png"
- >}}
+>}}
 
 {{< education-list
     title="Formation académique" >}}
@@ -54,48 +53,53 @@ draft = false
 {{< experience-section
     title="Mon expérience professionnelle (section)"
     intro_title="Introduction"
-    intro_description="Description.<br>Vous pouvez utiliser HTML, avec du texte en <strong>gras</strong>, ou des listes <ul><li>un</li><li>deux</li></ul>" 
+    intro_description="Description.<br>Vous pouvez utiliser du HTML, avec format <strong>gras</strong>, ou des listes <ul><li>un</li><li>deux</li></ul>"
     button1_url="https://example.com"
-    button1_text="Visiter l'exemple"
+    button1_text="Visiter Exemple"
     button1_icon="icon-globe"
-    button2_text="Autre bouton (2)"
-    button3_text="Bouton #3"
-    button3_url="/experience"
+    button2_text="Autre Bouton (2)"
+    button3_text="Tout voir"
+    button3_url="/es/experience"
 >}}
+
 ## Expérience (liste)
 
-{{< experience-list >}}
- 
+Vous pouvez voir une autre version, utilisant `experience-list` sur [/cv](/cv).
 
 {{< client-and-work-section
-    title="Une sélection de mes travaux" >}} 
+    title="Une sélection de mon travail" >}}
 
 {{< testimonial-section
-    title="Ce qu'ils disent de moi" >}}
+    title="Ce que l’on dit de moi" >}}
 
 {{< contact-section
-    title="Contact" 
+    title="Contact"
     contact_form_name="Votre nom ?"
-    contact_form_email="Votre e-mail"
+    contact_form_email="Votre adresse e-mail"
     contact_form_message="Votre message"
-    contact_button="Envoyer le message"
+    contact_button="Envoyer"
     contact_phone_title="Mon téléphone"
     contact_phone_number="<a href='tel:+555666777'>555 666 777</a>"
     contact_email_title="Mon e-mail"
     contact_email_email="demo@demosite.com"
-    contact_address_title="Ma localisation"
-    contact_address_address="🇩🇰 Danemark" >}}
+    contact_address_title="Mon emplacement"
+    contact_address_address="🇩🇰 Danemark"
+    form_action="/"
+    form_method="POST"
+>}}
 
-{{< newsletter-section 
+{{< newsletter-section
     newsletter_title="Restez informé"
     newsletter_placeholder="Entrez votre e-mail"
     newsletter_button="S'abonner"
-    newsletter_success_message="Merci de votre inscription !"
-    newsletter_error_message="Une erreur s'est produite, veuillez réessayer."
+    newsletter_success_message="Merci pour votre inscription !"
+    newsletter_error_message="Une erreur s’est produite, veuillez réessayer."
     newsletter_note="Nous respectons votre vie privée et ne partagerons pas vos données."
+    form_action="/"
+    form_method="POST"
 >}}
 
-Additional content added after the `section` blocks:
+Contenu supplémentaire après les blocs `section` :
 
 ```
 sections = [

--- a/exampleSite/content/home/home.fr.md
+++ b/exampleSite/content/home/home.fr.md
@@ -61,7 +61,6 @@ draft = false
     button2_text="Autre bouton (2)"
     button3_text="Bouton #3"
     button3_url="/experience"
-    social_links="aaa"
 >}}
 ## Expérience (liste)
 

--- a/exampleSite/content/home/home.md
+++ b/exampleSite/content/home/home.md
@@ -64,7 +64,6 @@ draft = false
     button2_url="/experience"
     button3_text="Button #3"
     button3_url="/experience"
-    social_links="aaa"
 >}}
 
 ## Experience (as list)

--- a/exampleSite/content/home/home.md
+++ b/exampleSite/content/home/home.md
@@ -66,7 +66,8 @@ draft = false
     button3_url="/experience"
     social_links="aaa"
 >}}
-## Experience (list)
+
+## Experience (as list)
 
 {{< experience-list >}}
 
@@ -83,11 +84,14 @@ draft = false
     contact_form_message="Your text"
     contact_button="Send message"
     contact_phone_title="My phone"
-    contact_phone_number="<a href='tel:+555 666 777'>555 666 777</a>"
+    contact_phone_number="<a href='tel:+555666777'>555 666 777</a>"
     contact_email_title="My mail"
     contact_email_email="demo@demosite.com"
     contact_address_title="My location"
-    contact_address_address="🇩🇰 Denmark" >}}
+    contact_address_address="🇩🇰 Denmark"
+    form_action="https://formspree.io/f/info@adrianmoreno.info"
+    form_method="POST"
+>}}
 
 {{< newsletter-section 
     newsletter_title="Stay updated"
@@ -96,6 +100,8 @@ draft = false
     newsletter_success_message="Thank you for subscribing!"
     newsletter_error_message="Something went wrong, please try again."
     newsletter_note="We respect your privacy and won't share your data."
+    form_action="/"
+    form_method="POST"
 >}}
 
 ## Extra content

--- a/layouts/partials/contact.html
+++ b/layouts/partials/contact.html
@@ -18,6 +18,7 @@
 {{- /* Form action and method */}}
 {{- $formAction := "" -}}
 {{- $formMethod := "" -}}
+aaa
 {{- if $isShortcode }}
     {{- $formAction = .Get "form_action" | default .Site.Data.homepage.contact.form.action -}}
     {{- $formMethod = .Get "form_method" | default .Site.Data.homepage.contact.form.method -}}

--- a/layouts/partials/contact.html
+++ b/layouts/partials/contact.html
@@ -18,7 +18,6 @@
 {{- /* Form action and method */}}
 {{- $formAction := "" -}}
 {{- $formMethod := "" -}}
-aaa
 {{- if $isShortcode }}
     {{- $formAction = .Get "form_action" | default .Site.Data.homepage.contact.form.action -}}
     {{- $formMethod = .Get "form_method" | default .Site.Data.homepage.contact.form.method -}}

--- a/layouts/partials/experience-description.html
+++ b/layouts/partials/experience-description.html
@@ -121,7 +121,7 @@
 <div class="container-experience">
   <div class="row">
     <h2>{{ $introTitle }}</h2>
-    <p class="lead">{{ $introDescription }}</p>
+    <div class="lead">{{ $introDescription }}</div>
   </div>
 
   <div class="row">

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -46,21 +46,21 @@
         {{- $css = $css | minify | fingerprint | resources.PostProcess }} 
     {{- end }}
     <link
-      rel="preload"
-      href="{{ $css.RelPermalink }}"
-      as="style"
-      onload="this.onload=null;this.rel='stylesheet'"
+      rel="preload" 
+      href="{{ $css.RelPermalink }}" 
+      as="style" 
+      onload="this.onload=null;this.rel='stylesheet'" 
       {{- if hugo.IsProduction -}} 
-        integrity="{{ $css.Data.Integrity }}"
+        integrity="{{ $css.Data.Integrity }}" 
         crossorigin="anonymous"
       {{- end -}}
     />
     <noscript>
       <link 
         rel="stylesheet"
-        href="{{ $css.RelPermalink }}"
+        href="{{ $css.RelPermalink }}" 
         {{- if hugo.IsProduction -}} 
-        integrity="{{ $css.Data.Integrity }}"
+        integrity="{{ $css.Data.Integrity }}" 
         crossorigin="anonymous"
         {{- end -}}
       />

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -50,19 +50,19 @@
       href="{{ $css.RelPermalink }}" 
       as="style" 
       onload="this.onload=null;this.rel='stylesheet'" 
-      {{- if hugo.IsProduction -}} 
-        integrity="{{ $css.Data.Integrity }}" 
-        crossorigin="anonymous"
-      {{- end -}}
+      {{ if hugo.IsProduction }} 
+      integrity="{{ $css.Data.Integrity }}" 
+      crossorigin="anonymous"
+      {{ end }}
     />
     <noscript>
       <link 
         rel="stylesheet"
         href="{{ $css.RelPermalink }}" 
-        {{- if hugo.IsProduction -}} 
+        {{ if hugo.IsProduction }} 
         integrity="{{ $css.Data.Integrity }}" 
         crossorigin="anonymous"
-        {{- end -}}
+        {{ end }}
       />
     </noscript>
 {{- end }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -50,19 +50,19 @@
       href="{{ $css.RelPermalink }}"
       as="style"
       onload="this.onload=null;this.rel='stylesheet'"
-      {{ if hugo.IsProduction -}} 
+      {{- if hugo.IsProduction -}} 
         integrity="{{ $css.Data.Integrity }}"
         crossorigin="anonymous"
-      {{- end }}
+      {{- end -}}
     />
     <noscript>
       <link 
         rel="stylesheet"
         href="{{ $css.RelPermalink }}"
-        {{ if hugo.IsProduction -}} 
+        {{- if hugo.IsProduction -}} 
         integrity="{{ $css.Data.Integrity }}"
         crossorigin="anonymous"
-        {{- end }}
+        {{- end -}}
       />
     </noscript>
 {{- end }}

--- a/layouts/partials/newsletter.html
+++ b/layouts/partials/newsletter.html
@@ -1,6 +1,20 @@
 {{ $contextType := printf "%T" . }}
 {{ $isShortcode := (eq $contextType "*hugolib.ShortcodeWithPage") }}
 
+{{/* ---------------------------------------------------------------------------
+     NEWSLETTER FORM CONFIGURATION
+     --------------------------------------------------------------------------- */}}
+{{- /* Form action and method */}}
+{{- $formAction := "" -}}
+{{- $formMethod := "" -}}
+{{- if $isShortcode }}
+    {{- $formAction = .Get "form_action" | default .Site.Data.homepage.newsletter.form.action -}}
+    {{- $formMethod = .Get "form_method" | default .Site.Data.homepage.newsletter.form.method -}}
+{{ else }}
+    {{- $formAction = .Site.Data.homepage.newsletter.form.action -}}
+    {{- $formMethod = .Site.Data.homepage.newsletter.form.method -}}
+{{ end }}
+
 <section id="newsletter" class="section section--cta">
   <div class="container">
     <div class="row">
@@ -15,8 +29,8 @@
         <div class="rad-subscription-group">
           <form
             id="rad-subscription"
-            action="{{ .Site.Data.homepage.newsletter.form.action }}" 
-            method="{{ .Site.Data.homepage.newsletter.form.method }}"
+            action="{{ $formAction }}"
+            method="{{ $formMethod }}"
           >
             <input
               id="rad-subscription-email"

--- a/layouts/shortcodes/experience-list.html
+++ b/layouts/shortcodes/experience-list.html
@@ -1,4 +1,4 @@
-<section id="experience-list" class="section-experience section section--border-bottom rad-animation-group flex-grow-1">
+<section id="experience-list-shortcode" class="section-experience section section--border-bottom rad-animation-group flex-grow-1">
     <div class="row flex-column-reverse flex-md-row rad-fade-down">
         <div class="experience-list col-12 mt-5 mt-sm-0">
             {{ $xp := (where .Site.RegularPages.ByDate "Type" "experience") }}


### PR DESCRIPTION
Noticed in https://github.com/zetxek/adritian-free-hugo-theme/actions/runs/13618970752.

passing now with the local html and https://validator.w3.org/nu/#l1568c53 
<img width="1432" alt="image" src="https://github.com/user-attachments/assets/e599225d-dcf1-4ab2-acd4-ed510cfbfbf1" />


- [x] english homepage
- [x] Spanish homepage
- [x] french homepage
- [x] experience page

Fixed as well the action that validates HTML: if the trigger has been a PR, it will use the code in the _PR branch_ (instead of directly the code in `main`, as that defeats the purpose of running the action against the PR :) 