### PR TITLE
Link decoration consistency

### DIFF
--- a/assets/scss/_menu.scss
+++ b/assets/scss/_menu.scss
@@ -26,14 +26,12 @@ $transition: 280ms all 120ms ease-out;
 }
 
 
-html[data-bs-theme="light"] {
-    // footer button
-    .footer_right button.btn{
-        color: white;
-    }
+// footer button
+.footer_right button.btn{
+    color: white;
+}
 
-    // dropdown item links
-    .footer_right .btn-link .dropdown-item {
-        color: $color;
-    }
+// dropdown item links
+.footer_right .btn-link .dropdown-item {
+    color: $color;
 }

--- a/assets/scss/_menu.scss
+++ b/assets/scss/_menu.scss
@@ -25,8 +25,15 @@ $transition: 280ms all 120ms ease-out;
     }
 }
 
-.footer_right button.btn,
-.footer_right .btn-link:hover,
-.footer_right .btn-link:focus {
-    color: white;
+
+html[data-bs-theme="light"] {
+    // footer button
+    .footer_right button.btn{
+        color: white;
+    }
+
+    // dropdown item links
+    .footer_right .btn-link .dropdown-item {
+        color: $color;
+    }
 }

--- a/assets/scss/_menu.scss
+++ b/assets/scss/_menu.scss
@@ -27,7 +27,8 @@ $transition: 280ms all 120ms ease-out;
 
 
 // footer button
-.footer_right button.btn{
+.footer_right button.btn,
+.footer_right button.btn:active{
     color: white;
 }
 

--- a/assets/scss/adritian.scss
+++ b/assets/scss/adritian.scss
@@ -140,8 +140,10 @@ p a,
 span a {
     color: #000;
     font-weight: 600;
-    text-decoration: none;
-    border-bottom: 1px solid rgba(0, 0, 0, 0.5);
+    text-decoration: underline;
+    text-underline-position: from-font;
+    text-decoration-style: solid;
+    text-decoration-thickness: 1px;
     transition: all 0.5s;
 }
 
@@ -149,7 +151,6 @@ span a {
 p a:hover,
 span a:hover {
     color: $base-color;
-    text-decoration: none;
 }
 
 .lead {


### PR DESCRIPTION
<img width="1456" alt="image" src="https://github.com/user-attachments/assets/cb217639-bde6-476b-8c9c-2f0e51667ff9" />

Before:

<img width="760" alt="image" src="https://github.com/user-attachments/assets/ddae8733-bd4c-4ec6-a2ac-89e32b22adbf" />

After:
<img width="598" alt="image" src="https://github.com/user-attachments/assets/3402a241-b297-4cb2-a8f0-e03c85ccfe6f" />
<img width="438" alt="image" src="https://github.com/user-attachments/assets/20e1255d-8cad-49bc-9fc9-5cd082f03688" />




This pull request introduces updates to the SCSS files to improve styling consistency and enhance the user interface. The changes primarily focus on refining button and link styles, as well as adding support for theme-based styling.

### Theme-based styling updates:
* [`assets/scss/_menu.scss`](diffhunk://#diff-80f14ca82735b0622cdac27a4829674b5063e883626094ed51aac6f231d88f10L28-R39): Introduced theme-specific styles for light mode, including updates to footer buttons and dropdown item links to ensure proper color application based on the theme.

### Link styling enhancements:
* [`assets/scss/adritian.scss`](diffhunk://#diff-d2657e38837f7230f8c0a04667ed5c3c2241e81931889bf9c9bc59013903059dL143-L152): Updated link styles to include underlines with specific thickness, style, and position, replacing the previous border-bottom approach. This change also ensures hover effects are consistent with the updated design.