### PR TITLE
Responsive experience list improvements, general responsive improvements, new "spacer" shortcode

### DIFF
--- a/exampleSite/content/blog/shortcodes.md
+++ b/exampleSite/content/blog/shortcodes.md
@@ -34,8 +34,10 @@ The shortcodes can be customized with different arguments:
   - `items`: A list of educational qualifications, they're provided by the `education` content type pages. From each, the `year`, `university`, and `degree` will be used.  
 
 - `experience-list`:
-  - `title`: The title of the experience section.
+  - `title`: The title of the experience section (optional). When provided, an h2 heading is added above the list.
+  - `padding`: Controls whether the section has padding. Set to "true" by default.
   - `items`: A list of professional experiences, coming from the `experience` content type. For each of them, the `companyLogo`, `duration`, `jobTitle`, `location`, and `Content` are used.
+  - **Note**: On mobile devices, a separator line is automatically added between experience entries for better readability.
 
 - `platform-links`:
   - `platforms`: A container to place social links inside. Usually you'll want to use it with a list of `link` nested (see below) 
@@ -144,6 +146,8 @@ The shortcodes can be customized with different arguments:
     - `imgScale` - Specifies the scale used for the image (for example, `0.5` if the high resolution image is double the size of the smaller one) This is only considered if neither imgWidth nor imgHeight is used.
   - **Social Media**:
     - `social_links`: Array of social media platform links to display at the bottom of the showcase. Each item should have a URL and icon property.
+  - **Responsive Behavior**:
+    - The showcase uses a two-column layout on desktop devices (≥768px) and stacks columns vertically on mobile devices, with the image appearing above the text content.
   - **Inner Content**:
     - The shortcode can also accept inner content that will be rendered in a separate div with class "inner-content".
 

--- a/exampleSite/content/blog/shortcodes.md
+++ b/exampleSite/content/blog/shortcodes.md
@@ -26,6 +26,7 @@ The theme provides custom shortcodes to allow you to customize your landing page
 - `testimonial-section`: Adds references from customers, colleagues, etc.
 - `showcase`: two-column block with a full-width image to the left, and a text snippet to the right. Great for a call to action or introduction of the person (assuming it's a personal website).
 - `text-section`: utility shortcode used to render text in some parts of the theme where it would otherwise be full-width, appearing "too floaty". See [the github issue #260 for context](https://github.com/zetxek/adritian-free-hugo-theme/issues/260).
+- `spacer`: Adds vertical spacing before the next element.
 
 The shortcodes can be customized with different arguments:
 
@@ -161,7 +162,14 @@ The shortcodes can be customized with different arguments:
   - **Inner Content**:
     - The shortcode accepts markdown-formatted inner content that will be rendered in the text section.
 
-
+- `spacer`: 
+  - **Size Options**:
+    - `size`: Controls the amount of vertical spacing. Accepts "small", "medium" (default), "large", or "xlarge".
+  - **Usage Examples**:
+    - `{{</* spacer */>}}`: Adds medium spacing (default)
+    - `{{</* spacer size="small" */>}}`: Adds minimal spacing
+    - `{{</* spacer size="large" */>}}`: Adds substantial spacing
+    - `{{</* spacer size="xlarge" */>}}`: Adds maximum spacing
 
 You can see them in effect in:
 - [the homepage](/) [`(see source)`](https://raw.githubusercontent.com/zetxek/adritian-demo/refs/heads/main/content/home.md).

--- a/exampleSite/content/home/home.md
+++ b/exampleSite/content/home/home.md
@@ -65,9 +65,8 @@ draft = false
     button3_url="/experience"
 >}}
 
-## Experience (as list)
-
 {{< experience-list
+    title="Experience (as list)"
     padding="false" >}}
 
 {{< client-and-work-section

--- a/exampleSite/content/home/home.md
+++ b/exampleSite/content/home/home.md
@@ -75,12 +75,15 @@ draft = false
 {{< testimonial-section
     title="What they say about me" >}}
 
+{{< spacer size="large" >}}
 
 ## Extra home content
 
 Additional content added after the `section` blocks, in the `home.md` file. 
 
 Here you could freestyle, add other shortcodes, ...  Or just let the content empty, and rely on the shortcode sections alone.
+
+{{< spacer size="small" >}}
 
 {{< text-section
 title="Extra (centered) content"

--- a/layouts/shortcodes/experience-list.html
+++ b/layouts/shortcodes/experience-list.html
@@ -13,7 +13,7 @@
 
             {{ range first $xpCount (sort $xp "Date" "desc") }}
             <div class="experience row">
-                <div class="experience__header col-3 d-flex align-items-start">
+                <div class="experience__header col-12 col-md-3 d-flex align-items-start">
                     {{ $img := resources.Get .Params.companyLogo }}
                     {{ with $img }}
                     {{ $imgWebp := $img.Resize (printf "%dx%d webp q75 Lanczos picture" $img.Width $img.Height) }}
@@ -27,7 +27,7 @@
                                 {{ .Params.location }}</span></div>
                     </div>
                 </div>
-                <div class="experience__description d-print-block col-9">
+                <div class="experience__description d-print-block col-12 col-md-9 mt-3 mt-md-0">
                     <h1>{{ .Params.title }}</h1>
                     {{ .Content | safeHTML }}
                 </div>

--- a/layouts/shortcodes/experience-list.html
+++ b/layouts/shortcodes/experience-list.html
@@ -1,4 +1,5 @@
 {{ $padding := .Get "padding" }}
+{{ $title := .Get "title" | default "" }}
 {{ $containerClass := "" }}
 {{ if eq $padding "true" }}
     {{ $containerClass = "container" }}
@@ -7,6 +8,10 @@
 <section id="experience-list-shortcode" class="section-experience section section--border-bottom rad-animation-group flex-grow-1 {{ $containerClass }}">
     <div class="row flex-column-reverse flex-md-row rad-fade-down">
         <div class="experience-list col-12 mt-5 mt-sm-0">
+            {{ if $title }}
+            <h2 class="section__title mb-4">{{ $title }}</h2>
+            {{ end }}
+            
             {{ $xp := (where .Site.RegularPages.ByDate "Type" "experience") }}
 
             {{ $xpCount := len $xp }}

--- a/layouts/shortcodes/experience-list.html
+++ b/layouts/shortcodes/experience-list.html
@@ -11,7 +11,7 @@
 
             {{ $xpCount := len $xp }}
 
-            {{ range first $xpCount (sort $xp "Date" "desc") }}
+            {{ range $index, $element := first $xpCount (sort $xp "Date" "desc") }}
             <div class="experience row">
                 <div class="experience__header col-12 col-md-3 d-flex align-items-start">
                     {{ $img := resources.Get .Params.companyLogo }}
@@ -32,6 +32,10 @@
                     {{ .Content | safeHTML }}
                 </div>
             </div>
+            {{ if ne $index (sub $xpCount 1) }}
+            <!-- Separator between experiences for mobile -->
+            <hr class="d-block d-md-none my-4">
+            {{ end }}
             {{ end }}
         </div>
     </div>

--- a/layouts/shortcodes/spacer.html
+++ b/layouts/shortcodes/spacer.html
@@ -1,0 +1,14 @@
+{{ $size := .Get "size" | default "medium" }}
+{{ $class := "" }}
+
+{{ if eq $size "small" }}
+    {{ $class = "pt-3" }}
+{{ else if eq $size "medium" }}
+    {{ $class = "pt-5" }}
+{{ else if eq $size "large" }}
+    {{ $class = "pt-5 mt-4" }}
+{{ else if eq $size "xlarge" }}
+    {{ $class = "pt-5 mt-5" }}
+{{ end }}
+
+<div class="spacer {{ $class }}"></div>


### PR DESCRIPTION
Multiple responsive improvements

1. Created new shortcode, `spacer`, to prevent texts from being too close to existing shortcode sections

Before:
![image](https://github.com/user-attachments/assets/a41f318d-2416-4ca1-addb-6330b254a4f5)

After:
<img width="1368" alt="image" src="https://github.com/user-attachments/assets/668218ef-53de-4da7-b279-b0b922398695" />


2. Improved responsive `experience-list` experience, with the logo and company name displaying on top on mobile
<img width="1058" alt="SCR-20250418-okhs" src="https://github.com/user-attachments/assets/770bee98-28da-4c9b-a786-8c4ada86c67b" />
<img width="677" alt="SCR-20250418-okju" src="https://github.com/user-attachments/assets/09f88c3a-e80e-4d5c-ba6c-c59dfc204872" />

3. Added separator in between experience items in `experience-list` in mobile (as the layout was a bit more confusing)

<img width="711" alt="SCR-20250418-omaf" src="https://github.com/user-attachments/assets/93ba62a8-366a-451d-9c9f-4dbbb0db44c2" />

The theme keeps on getting shortcodes to allow easy customization within the `markdown` elements, without having to code the pages. 
