### PR TITLE
fix: add id to main-content section in 404 page for better accessibility

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-    <section class="section four-o-four">
+    <section id="main-content" class="section four-o-four">
       <div class="container text-center">
         <h1 class="display-1">404</h1>
         <h4>{{ i18n "404_title" }}</h4>


### PR DESCRIPTION
Simple fix, the 404 page missed its `main-content` id. 

![2025-04-20 19 52 01](https://github.com/user-attachments/assets/1813e124-8e13-4a3a-83ea-d3444bb792da)
