### PR TITLE
Feature request 284: add ability to translate url slugs

### DIFF
--- a/exampleSite/content/blog/shortcodes.md
+++ b/exampleSite/content/blog/shortcodes.md
@@ -33,20 +33,24 @@ The shortcodes can be customized with different arguments:
 - `education-list`:
   - `title`: The title of the education section.
   - `items`: A list of educational qualifications, they're provided by the `education` content type pages. From each, the `year`, `university`, and `degree` will be used.  
+  - `sectionId`: Optional. Overrides the default HTML id for the section. If not provided, the default id is used.
 
 - `experience-list`:
   - `title`: The title of the experience section (optional). When provided, an h2 heading is added above the list.
   - `padding`: Controls whether the section has padding. Set to "true" by default.
   - `items`: A list of professional experiences, coming from the `experience` content type. For each of them, the `companyLogo`, `duration`, `jobTitle`, `location`, and `Content` are used.
   - **Note**: On mobile devices, a separator line is automatically added between experience entries for better readability.
+  - `sectionId`: Optional. Overrides the default HTML id for the section. If not provided, the default id is used.
 
 - `platform-links`:
   - `platforms`: A container to place social links inside. Usually you'll want to use it with a list of `link` nested (see below) 
+  - `sectionId`: Optional. Overrides the default HTML id for the section. If not provided, the default id is used.
 
 - `link`: links to social platforms (facebook, linkedin, etc)
   - `url`: The URL for the hyperlink.
   - `icon`: The icon to display with the link.
-   
+  - `sectionId`: Optional. Overrides the default HTML id for the section. If not provided, the default id is used.
+
 - `newsletter-section`:
   - **Form Configuration**:
     - `form_action`: The URL where the newsletter form data will be submitted. Falls back to site data configuration (typically set in data/homepage.yaml).
@@ -59,10 +63,12 @@ The shortcodes can be customized with different arguments:
     - `newsletter_success_message`: Message displayed to users after successful subscription. Falls back to i18n value "newsletter_success_message".
     - `newsletter_error_message`: Message displayed to users if subscription fails. Falls back to i18n value "newsletter_error_message".
     - `newsletter_note`: Small text/disclaimer shown below the form (typically mentions privacy policy). Falls back to i18n value "newsletter_note".
+  - `sectionId`: Optional. Overrides the default HTML id for the section. If not provided, the default id is used.
 
 - `experience-section`:
   - `title`: The title of the experience section.
   - `experiences`: A detailed list of experiences, coming from the `experience` content type pages.
+  - `sectionId`: Optional. Overrides the default HTML id for the section. If not provided, the default id is used.
 
 - `contact-section`:
   - `title`: Sets the main heading/title for the contact section. Falls back to the i18n value "contact_title" if not provided.
@@ -81,12 +87,13 @@ The shortcodes can be customized with different arguments:
     - `contact_email_email`: Email address to display. Falls back to i18n value.
     - `contact_address_title`: Heading for the address section. Falls back to i18n value.
     - `contact_address_address`: Physical address or location information. Falls back to i18n value.
-
+  - `sectionId`: Optional. Overrides the default HTML id for the section. If not provided, the default id is used.
 
 - `client-and-work-section`: this shortcode doesn't use as many arguments - as much of the content comes from other content pages.
   - `title`: The title of the client and work section.
   - `clients`: A list of clients, coming from the `client` content type (each with `title`, `link`, `logo`)
   - `projects`: A list of projects, coming from the `project` content type (each with `title`, `content`, `button.URL`, `button.btnText`, `button.icon`, `image`).
+  - `sectionId`: Optional. Overrides the default HTML id for the section. If not provided, the default id is used.
 
 - `about-section`:
   - Content Arguments
@@ -120,6 +127,8 @@ The shortcodes can be customized with different arguments:
 
       - `button2_text` - Text label to display on the secondary button. Falls back to the text from site data.
 
+  - `sectionId`: Optional. Overrides the default HTML id for the section. If not provided, the default id is used.
+
   - `testimonial-section`:
     - `title`: The title of the testimonial section.
     - `testimonials`: A list of testimonials, provided by the `testimonial` content type pages. The partial dynamically pulls content from pages with type "testimonial". Each testimonial page should include:
@@ -128,8 +137,7 @@ The shortcodes can be customized with different arguments:
         - `name`: The name of the person giving the testimonial
         - `position`: The job title or role of the person giving the testimonial
         - `image.src`: Path to the image of the testimonial author
-
-
+    - `sectionId`: Optional. Overrides the default HTML id for the section. If not provided, the default id is used.
 
 - `showcase`: 
   - **Content Arguments**:
@@ -151,6 +159,7 @@ The shortcodes can be customized with different arguments:
     - The showcase uses a two-column layout on desktop devices (≥768px) and stacks columns vertically on mobile devices, with the image appearing above the text content.
   - **Inner Content**:
     - The shortcode can also accept inner content that will be rendered in a separate div with class "inner-content".
+  - `sectionId`: Optional. Overrides the default HTML id for the section. If not provided, the default id is used.
 
 - `text-section`: 
   - **Content Arguments**:
@@ -161,6 +170,7 @@ The shortcodes can be customized with different arguments:
     - `centered`: When set to "true", adds flexbox classes to center the content both horizontally and vertically. Set to "false" by default.
   - **Inner Content**:
     - The shortcode accepts markdown-formatted inner content that will be rendered in the text section.
+  - `sectionId`: Optional. Overrides the default HTML id for the section. If not provided, the default id is used.
 
 - `spacer`: 
   - **Size Options**:
@@ -170,6 +180,7 @@ The shortcodes can be customized with different arguments:
     - `{{</* spacer size="small" */>}}`: Adds minimal spacing
     - `{{</* spacer size="large" */>}}`: Adds substantial spacing
     - `{{</* spacer size="xlarge" */>}}`: Adds maximum spacing
+  - `sectionId`: Optional. Overrides the default HTML id for the section. If not provided, the default id is used.
 
 You can see them in effect in:
 - [the homepage](/) [`(see source)`](https://raw.githubusercontent.com/zetxek/adritian-demo/refs/heads/main/content/home.md).

--- a/exampleSite/content/footer/footer.es.md
+++ b/exampleSite/content/footer/footer.es.md
@@ -1,0 +1,48 @@
++++
+title =  "Footer"
+type = "footer"
+draft = false
++++
+
+
+{{< contact-section
+    sectionId="contacto"
+    title="Contáctame" 
+    contact_form_name="Tu nombre"
+    contact_form_email="Tu correo"
+    contact_form_message="Tu mensaje"
+    contact_button="Enviar mensaje"
+    contact_phone_title="Mi teléfono"
+    contact_phone_number="<a href='tel:+555666777'>555 666 777</a>"
+    contact_email_title="Mi correo"
+    contact_email_email="demo@demosite.com"
+    contact_address_title="Mi ubicación"
+    contact_address_address="🇩🇰 Denmark"
+    form_action="https://formspree.io/f/mail@example.com"
+    form_method="POST"
+>}}
+
+{{< newsletter-section 
+    newsletter_title="Subscríbete"
+    newsletter_placeholder="Tu correo"
+    newsletter_button="Subscríbete"
+    newsletter_success_message="Gracias por suscribirte!"
+    newsletter_error_message="Algo ha fallado, por favor inténtalo de nuevo."
+    newsletter_note="Respetamos tu privacidad."
+    form_action="/"
+    form_method="POST"
+>}}
+
+
+{{< text-section
+title="Contenido extra"
+centered="true"
+>}}
+
+Puedes añadir contenido adicional después de los bloques de `section`.
+
+Aquí puedes ser creativo, utilizar otros shortcodes, ... O dejarlo vacío.
+
+Para añadir texto que quede bien en el pie, puedes utilizar el shortcode `text-section`.
+
+{{< /text-section >}}

--- a/exampleSite/content/home/home.es.md
+++ b/exampleSite/content/home/home.es.md
@@ -11,9 +11,10 @@ draft = false
     description="Texto en <strong>negrita</strong> y normal. Esto viene de <code>home.md</code>. ¿No proporcionado? se usa i18n por defecto (por ahora, para ofrecer compatibilidad con versiones >1.7.0)"
     imgSrc="images/showcase/showcase.png"
     imgScale="0.5"
+    sectionId="seccion-destacada"
  >}}
 
-{{< platform-links >}}
+{{< platform-links sectionId="enlaces-plataforma" >}}
     {{< link icon="square-facebook" url="https://facebook.com/yourpage" >}}
     {{< link icon="square-twitter" url="https://twitter.com/yourpage" >}}
     {{< link icon="linkedin" url="https://www.linkedin.com/in/adrianmoreno/" >}}
@@ -46,10 +47,12 @@ draft = false
     button_url="https://www.google.com"
     imgSrc="images/about/user-picture.png"
     imgScale="0.5"
+    sectionId="sobre-mi"
  >}}
 
 {{< education-list
-    title="Formación académica" >}}
+    title="Formación académica"
+    sectionId="formacion-academica" >}}
 
 {{< experience-section
     title="Mi experiencia laboral (sección)"
@@ -61,6 +64,7 @@ draft = false
     button2_text="Otro Botón (2)"
     button3_text="Ver todo"
     button3_url="/es/experience"
+    sectionId="experiencia-laboral"
 >}}
 
 
@@ -70,7 +74,9 @@ Puedes ver una versión alternativa, usando `experience-list` en [/cv](/cv).
  
 
 {{< client-and-work-section
-    title="Una selección de mi trabajo" >}} 
+    title="Una selección de mi trabajo"
+    sectionId="trabajo" >}} 
 
 {{< testimonial-section
-    title="Lo que dicen de mí" >}}
+    title="Lo que dicen de mí"
+    sectionId="testimonios" >}}

--- a/exampleSite/content/home/home.es.md
+++ b/exampleSite/content/home/home.es.md
@@ -14,7 +14,7 @@ draft = false
     sectionId="seccion-destacada"
  >}}
 
-{{< platform-links sectionId="enlaces-plataforma" >}}
+{{< platform-links sectionId="social" >}}
     {{< link icon="square-facebook" url="https://facebook.com/yourpage" >}}
     {{< link icon="square-twitter" url="https://twitter.com/yourpage" >}}
     {{< link icon="linkedin" url="https://www.linkedin.com/in/adrianmoreno/" >}}

--- a/exampleSite/content/home/home.fr.md
+++ b/exampleSite/content/home/home.fr.md
@@ -11,9 +11,10 @@ draft = false
     description="Texte en <strong>gras</strong> et normal. Ceci provient de <code>home.md</code>. Non fourni ? i18n par défaut (pour compatibilité versions >1.7.0)"
     imgSrc="images/showcase/showcase.png"
     imgScale="0.5"
+    sectionId="section-vedette"
 >}}
 
-{{< platform-links >}}
+{{< platform-links sectionId="liens-plateforme" >}}
     {{< link icon="square-facebook" url="https://facebook.com/yourpage" >}}
     {{< link icon="square-twitter" url="https://twitter.com/yourpage" >}}
     {{< link icon="linkedin" url="https://www.linkedin.com/in/adrianmoreno/" >}}
@@ -45,10 +46,12 @@ draft = false
     button_url="https://www.google.com"
     imgSrc="images/about/user-picture.png"
     imgScale="0.5"
+    sectionId="a-propos"
 >}}
 
 {{< education-list
-    title="Formation académique" >}}
+    title="Formation académique"
+    sectionId="formation-academique" >}}
 
 {{< experience-section
     title="Mon expérience professionnelle (section)"
@@ -60,14 +63,17 @@ draft = false
     button2_text="Autre Bouton (2)"
     button3_text="Tout voir"
     button3_url="/es/experience"
+    sectionId="experience-professionnelle"
 >}}
 
 ## Expérience (liste)
 
-Vous pouvez voir une autre version, utilisant `experience-list` sur [/cv](/cv).
+Vous pouvez voir une autre version, utilisant `experience-list` sur [/cv](/cv].
 
 {{< client-and-work-section
-    title="Une sélection de mon travail" >}}
+    title="Une sélection de mon travail"
+    sectionId="travail" >}}
 
 {{< testimonial-section
-    title="Ce que l’on dit de moi" >}}
+    title="Ce que l’on dit de moi"
+    sectionId="temoignages" >}}

--- a/exampleSite/content/home/home.fr.md
+++ b/exampleSite/content/home/home.fr.md
@@ -68,7 +68,7 @@ draft = false
 
 ## Expérience (liste)
 
-Vous pouvez voir une autre version, utilisant `experience-list` sur [/cv](/cv].
+Vous pouvez voir une autre version, utilisant `experience-list` sur [/cv](/cv).
 
 {{< client-and-work-section
     title="Une sélection de mon travail"

--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -197,11 +197,11 @@ URL = "/es/"
 weight = 1
 [[languages.es.menus.header]]
 name = 'Sobre mi'
-URL = '/es/#about'
+URL = '/es/#sobre-mi'
 weight = 2
 [[languages.es.menus.header]]
-name = 'Portfolio'
-URL = '/es/#portfolio'
+name = 'Trabajo'
+URL = '/es/#trabajo'
 weight = 3
 
 #  [[languages.es.menus.header]]
@@ -218,7 +218,7 @@ weight = 5
 [[languages.es.menus.header]]
 pre = "email"
 name = "Contacto"
-URL = "/es/#contact"
+URL = "/es/#contacto"
 weight = 6
 
 [[languages.es.menus.header]]

--- a/layouts/partials/about.html
+++ b/layouts/partials/about.html
@@ -52,8 +52,14 @@
   {{- $btnText = i18n "about_button" -}}
 {{ end }}
 
+{{/*
+  sectionId: Optional argument to override the default HTML id for this section. If not provided, the default id is used. */}}
+{{ $sectionId := "about" }}
+{{ with .Get "sectionId" }}
+  {{ $sectionId = . }}
+{{ end }}
 
-<section id="about" class="section rad-animation-group pb-0">
+<section id="{{ $sectionId }}" class="section rad-animation-group pb-0">
   <div class="rad-fade-down">
     <div class="row d-flex flex-column-reverse flex-md-row">
       <div class="about__profile-picture col-12 col-md-6">

--- a/layouts/partials/about.html
+++ b/layouts/partials/about.html
@@ -59,7 +59,7 @@
   {{ $sectionId = . }}
 {{ end }}
 
-<section id="{{ $sectionId }}" class="section rad-animation-group pb-0">
+<section {{if $sectionId}} id="{{ $sectionId }}"{{end}} class="section rad-animation-group pb-0">
   <div class="rad-fade-down">
     <div class="row d-flex flex-column-reverse flex-md-row">
       <div class="about__profile-picture col-12 col-md-6">

--- a/layouts/partials/client-and-work.html
+++ b/layouts/partials/client-and-work.html
@@ -37,7 +37,7 @@
   {{ $sectionId = . }}
 {{ end }}
 
-<section id="{{ $sectionId }}" class="section section--border-bottom">
+<section {{if $sectionId}} id="{{ $sectionId }}"{{end}} class="section section--border-bottom">
   <div class="client-works-container">
     <h2 class="rad-animation-group rad-fade-down">
       {{ $sectionTitle }}

--- a/layouts/partials/client-and-work.html
+++ b/layouts/partials/client-and-work.html
@@ -30,7 +30,14 @@
      --------------------------------------------------------------------------- */}}
 {{- $projects := (where .Site.RegularPages.ByDate.Reverse "Type" "projects") -}}
 
-<section id="portfolio" class="section section--border-bottom">
+{{/*
+  sectionId: Optional argument to override the default HTML id for this section. If not provided, the default id is used. */}}
+{{ $sectionId := "client-and-work-section" }}
+{{ with .Get "sectionId" }}
+  {{ $sectionId = . }}
+{{ end }}
+
+<section id="{{ $sectionId }}" class="section section--border-bottom">
   <div class="client-works-container">
     <h2 class="rad-animation-group rad-fade-down">
       {{ $sectionTitle }}

--- a/layouts/partials/contact.html
+++ b/layouts/partials/contact.html
@@ -1,6 +1,13 @@
 {{- $contextType := printf "%T" . -}}
 {{- $isShortcode := (eq $contextType "*hugolib.ShortcodeWithPage") -}}
 
+{{/*
+  sectionId: Optional argument to override the default HTML id for this section. If not provided, the default id is used. */}}
+{{ $sectionId := "contact" }}
+{{ with .Get "sectionId" }}
+  {{ $sectionId = . }}
+{{ end }}
+
 {{/* ---------------------------------------------------------------------------
      CONTACT FORM ELEMENTS
      --------------------------------------------------------------------------- */}}
@@ -79,7 +86,7 @@
     {{- $addressText = i18n "contact_address_address" -}}
 {{ end }}
 
-<section id="contact" class="section section--contact pt-0">
+<section id="{{ $sectionId }}" class="section section--contact pt-0">
     <div class="container">
         <div class="contact w-100">
             <h2>{{ $title }}</h2>

--- a/layouts/partials/contact.html
+++ b/layouts/partials/contact.html
@@ -1,136 +1,120 @@
-{{- $contextType := printf "%T" . -}}
-{{- $isShortcode := (eq $contextType "*hugolib.ShortcodeWithPage") -}}
-
 {{/*
+  contact.html, used via {{ partial "contact.html" . }}
+  from contact-section.html
+  
+  Arguments:
   sectionId: Optional argument to override the default HTML id for this section. If not provided, the default id is used. */}}
+
 {{ $sectionId := "contact" }}
 {{ with .Get "sectionId" }}
   {{ $sectionId = . }}
 {{ end }}
 
-{{/* ---------------------------------------------------------------------------
-     CONTACT FORM ELEMENTS
-     --------------------------------------------------------------------------- */}}
-{{- /* Title */}}
-{{- $title := "" -}}
-{{- if $isShortcode }}
-    {{- $title = .Get "title" -}}
-{{ else }}
-    {{- $title = i18n "contact_title" -}}
+{{/*----------------------------------------------
+    TITLE
+------------------------------------------------*/}}
+{{ $title := .Get "title" | default (i18n "contact_title") }}
+
+{{/*----------------------------------------------
+    FORM CONFIGURATION
+------------------------------------------------*/}}
+{{ $form_action := .Get "form_action" | default .Site.Data.homepage.contact.form_action }}
+{{ $form_method := .Get "form_method" | default .Site.Data.homepage.contact.form_method }}
+
+{{/*----------------------------------------------
+    FORM FIELD PLACEHOLDERS
+------------------------------------------------*/}}
+{{ $name_placeholder := .Get "name_placeholder" | default .Site.Data.homepage.contact.form_name_placeholder | default (i18n "contact_name_placeholder") }}
+{{ $name_placeholder_attr := "" }}
+{{ if $name_placeholder }}
+  {{ $name_placeholder_attr = printf "placeholder=%q" $name_placeholder }}
 {{ end }}
 
-{{/* ---------------------------------------------------------------------------
-     FORM CONFIGURATION
-     --------------------------------------------------------------------------- */}}
-{{- /* Form action and method */}}
-{{- $formAction := "" -}}
-{{- $formMethod := "" -}}
-{{- if $isShortcode }}
-    {{- $formAction = .Get "form_action" | default .Site.Data.homepage.contact.form.action -}}
-    {{- $formMethod = .Get "form_method" | default .Site.Data.homepage.contact.form.method -}}
-{{ else }}
-    {{- $formAction = .Site.Data.homepage.contact.form.action -}}
-    {{- $formMethod = .Site.Data.homepage.contact.form.method -}}
+{{ $email_placeholder := .Get "email_placeholder" | default .Site.Data.homepage.contact.form_email_placeholder | default (i18n "contact_email_placeholder") }}
+{{ $email_placeholder_attr := "" }}
+{{ if $email_placeholder }}
+  {{ $email_placeholder_attr = printf "placeholder=%q" $email_placeholder }}
 {{ end }}
 
-{{- /* Form placeholders */}}
-{{- $formName := "" -}}
-{{- $formEmail := "" -}}
-{{- $formMessage := "" -}}
-{{- $formButton := "" -}}
-{{- if $isShortcode }}
-    {{- $formName = .Get "contact_form_name" -}}
-    {{- $formEmail = .Get "contact_form_email" -}}
-    {{- $formMessage = .Get "contact_form_message" -}}
-    {{- $formButton = .Get "contact_button" -}}
-{{ else }}
-    {{- $formName = i18n "contact_form_name" -}}
-    {{- $formEmail = i18n "contact_form_email" -}}
-    {{- $formMessage = i18n "contact_form_message" -}}
-    {{- $formButton = i18n "contact_buton" -}}
+{{ $phone_placeholder := .Get "phone_placeholder" | default .Site.Data.homepage.contact.form_phone_placeholder | default (i18n "contact_phone_placeholder") }}
+{{ $phone_placeholder_attr := "" }}
+{{ if $phone_placeholder }}
+  {{ $phone_placeholder_attr = printf "placeholder=%q" $phone_placeholder }}
 {{ end }}
 
-{{/* ---------------------------------------------------------------------------
-     CONTACT INFO
-     --------------------------------------------------------------------------- */}}
-{{- /* Phone */}}
-{{- $phoneTitle := "" -}}
-{{- $phoneNumber := "" -}}
-{{- if $isShortcode }}
-    {{- $phoneTitle = .Get "contact_phone_title" -}}
-    {{- $phoneNumber = .Get "contact_phone_number" -}}
-{{ else }}
-    {{- $phoneTitle = i18n "contact_phone_title" -}}
-    {{- $phoneNumber = i18n "contact_phone_number" -}}
+{{ $message_placeholder := .Get "message_placeholder" | default .Site.Data.homepage.contact.form_message_placeholder | default (i18n "contact_message_placeholder") }}
+{{ $message_placeholder_attr := "" }}
+{{ if $message_placeholder }}
+  {{ $message_placeholder_attr = printf "placeholder=%q" $message_placeholder }}
 {{ end }}
 
-{{- /* Email */}}
-{{- $emailTitle := "" -}}
-{{- $emailAddress := "" -}}
-{{- if $isShortcode }}
-    {{- $emailTitle = .Get "contact_email_title" -}}
-    {{- $emailAddress = .Get "contact_email_email" -}}
-{{ else }}
-    {{- $emailTitle = i18n "contact_email_title" -}}
-    {{- $emailAddress = i18n "contact_email_email" -}}
-{{ end }}
+{{/*----------------------------------------------
+    BUTTON TEXT
+------------------------------------------------*/}}
+{{ $button_text := .Get "button_text" | default .Site.Data.homepage.contact.button_text | default (i18n "contact_button_text") }}
 
-{{- /* Address */}}
-{{- $addressTitle := "" -}}
-{{- $addressText := "" -}}
-{{- if $isShortcode }}
-    {{- $addressTitle = .Get "contact_address_title" -}}
-    {{- $addressText = .Get "contact_address_address" -}}
-{{ else }}
-    {{- $addressTitle = i18n "contact_address_title" -}}
-    {{- $addressText = i18n "contact_address_address" -}}
-{{ end }}
+{{/*----------------------------------------------
+    CONTACT INFORMATION FIELDS
+------------------------------------------------*/}}
+{{ $phone := .Get "phone" | default .Site.Data.homepage.contact.phone }}
+{{ $phone_display := .Get "phone_display" | default .Site.Data.homepage.contact.phone_display | default $phone }}
+{{ $email := .Get "email" | default .Site.Data.homepage.contact.email }}
+{{ $location := .Get "location" | default .Site.Data.homepage.contact.location }}
 
-<section id="{{ $sectionId }}" class="section section--contact pt-0">
+{{/*----------------------------------------------
+    HEADING LABELS
+------------------------------------------------*/}}
+{{ $phone_heading := .Get "phone_heading" | default .Site.Data.homepage.contact.phone_heading | default (i18n "contact_phone_heading") }}
+{{ $email_heading := .Get "email_heading" | default .Site.Data.homepage.contact.email_heading | default (i18n "contact_email_heading") }}
+{{ $location_heading := .Get "location_heading" | default .Site.Data.homepage.contact.location_heading | default (i18n "contact_location_heading") }}
+
+<section {{if $sectionId}} id="{{ $sectionId }}"{{end}} class="section section--contact pt-0">
     <div class="container">
         <div class="contact w-100">
             <h2>{{ $title }}</h2>
 
             <div class="row pt-2">
                 <div class="col-12 col-lg-7">
-                    <form action="{{ $formAction }}" method="{{ $formMethod }}">
+                    <form action="{{ $form_action }}" method="{{ $form_method }}">
                         <div class="row">
                             <div class="col-12 col-sm-6">
-                                <input type="text" name="full_name" id="full_name" placeholder="{{ $formName }}">
+                                <input type="text" name="full_name" class="form-control" {{ $name_placeholder_attr | safeHTMLAttr }}>
                             </div>
                             <div class="col-12 col-sm-6">
-                                <input type="text" name="email" id="email" placeholder="{{ $formEmail }}">
+                                <input type="email" name="email" class="form-control" {{ $email_placeholder_attr | safeHTMLAttr }}>
                             </div>
                         </div>
                         <div class="row pt-4">
                             <div class="col-12">
-                                <textarea name="message" id="message" cols="30" rows="3" placeholder="{{ $formMessage }}"></textarea>
+                                <input type="text" name="phone" class="form-control" {{ $phone_placeholder_attr | safeHTMLAttr }}>
                             </div>
                         </div>
                         <div class="row pt-4">
                             <div class="col-12">
-                                <button type="submit" class="btn btn-primary">
-                                    <i class="{{ .Site.Data.homepage.contact.button.icon }}"></i>
-                                    {{ $formButton }}
-                                </button>
+                                <textarea name="message" class="form-control" rows="6" {{ $message_placeholder_attr | safeHTMLAttr }}></textarea>
+                            </div>
+                        </div>
+                        <div class="row pt-4">
+                            <div class="col-12">
+                                <button type="submit" class="btn btn-primary">{{ $button_text }}</button>
                             </div>
                         </div>
                     </form>
                 </div>
                 <div class="col-12 col-lg-5 contact__info">
-                    {{ if $phoneNumber }}
-                    <h3>{{ $phoneTitle }}</h3>
-                    <span>{{ $phoneNumber | safeHTML }}</span>
+                    {{ if $phone }}
+                    <h3>{{ $phone_heading }}</h3>
+                    <span><a href='tel:{{ $phone }}'>{{ $phone_display }}</a></span>
                     {{ end }}
 
-                    {{ if $emailAddress }}
-                    <h3>{{ $emailTitle }}</h3>
-                    <span>{{ $emailAddress | safeHTML }}</span>
+                    {{ if $email }}
+                    <h3>{{ $email_heading }}</h3>
+                    <span>{{ $email }}</span>
                     {{ end }}
                     
-                    {{ if $addressText }}
-                    <h3>{{ $addressTitle }}</h3>
-                    <span>{{ $addressText | safeHTML }}</span>
+                    {{ if $location }}
+                    <h3>{{ $location_heading }}</h3>
+                    <span>{{ $location }}</span>
                     {{ end }}
                 </div>
             </div>

--- a/layouts/partials/education.html
+++ b/layouts/partials/education.html
@@ -1,6 +1,13 @@
 {{- $contextType := printf "%T" . -}}
 {{- $isShortcode := (eq $contextType "*hugolib.ShortcodeWithPage") -}}
 
+{{/*
+  sectionId: Optional argument to override the default HTML id for this section. If not provided, the default id is used. */}}
+{{ $sectionId := "education" }}
+{{ with .Get "sectionId" }}
+  {{ $sectionId = . }}
+{{ end }}
+
 {{- /* Title */}}
 {{- $title := "" -}}
 
@@ -11,7 +18,7 @@
 {{ end }}
 
 <section
-  id="education"
+  id="{{ $sectionId }}"
   class="section section--border-bottom rad-animation-group"
 >
   <div class="container-education">

--- a/layouts/partials/experience.html
+++ b/layouts/partials/experience.html
@@ -4,8 +4,10 @@
 {{/*
   sectionId: Optional argument to override the default HTML id for this section. If not provided, the default id is used. */}}
 {{ $sectionId := "experience-single" }}
-{{ with .Get "sectionId" }}
-  {{ $sectionId = . }}
+{{ if $isShortcode }}
+  {{ with .Get "sectionId" }}
+    {{ $sectionId = . }}
+  {{ end }}
 {{ end }}
 
 <section id="{{ $sectionId }}" class="section-experience section section--border-bottom rad-animation-group flex-grow-1">

--- a/layouts/partials/experience.html
+++ b/layouts/partials/experience.html
@@ -1,7 +1,14 @@
 {{ $contextType := printf "%T" . }}
 {{ $isShortcode := (eq $contextType "*hugolib.ShortcodeWithPage") }}
 
-<section id="experience-single" class="section-experience section section--border-bottom rad-animation-group flex-grow-1">
+{{/*
+  sectionId: Optional argument to override the default HTML id for this section. If not provided, the default id is used. */}}
+{{ $sectionId := "experience-single" }}
+{{ with .Get "sectionId" }}
+  {{ $sectionId = . }}
+{{ end }}
+
+<section id="{{ $sectionId }}" class="section-experience section section--border-bottom rad-animation-group flex-grow-1">
   <div class="row flex-column-reverse flex-md-row rad-fade-down">
     <div class="experience-list col-12 col-md-6">
       <h2>

--- a/layouts/partials/experience.html
+++ b/layouts/partials/experience.html
@@ -10,7 +10,7 @@
   {{ end }}
 {{ end }}
 
-<section id="{{ $sectionId }}" class="section-experience section section--border-bottom rad-animation-group flex-grow-1">
+<section {{if $sectionId}} id="{{ $sectionId }}"{{end}} class="section-experience section section--border-bottom rad-animation-group flex-grow-1">
   <div class="row flex-column-reverse flex-md-row rad-fade-down">
     <div class="experience-list col-12 col-md-6">
       <h2>

--- a/layouts/partials/newsletter.html
+++ b/layouts/partials/newsletter.html
@@ -22,7 +22,7 @@
   {{ $sectionId = . }}
 {{ end }}
 
-<section id="{{ $sectionId }}" class="section section--cta">
+<section {{if $sectionId}} id="{{ $sectionId }}"{{end}} class="section section--cta">
   <div class="container d-flex justify-content-center align-items-center">
     <div class="row">
       <div class="col-12 text-center">

--- a/layouts/partials/newsletter.html
+++ b/layouts/partials/newsletter.html
@@ -15,7 +15,14 @@
     {{- $formMethod = .Site.Data.homepage.newsletter.form.method -}}
 {{ end }}
 
-<section id="newsletter" class="section section--cta">
+{{/*
+  sectionId: Optional argument to override the default HTML id for this section. If not provided, the default id is used. */}}
+{{ $sectionId := "newsletter" }}
+{{ with .Get "sectionId" }}
+  {{ $sectionId = . }}
+{{ end }}
+
+<section id="{{ $sectionId }}" class="section section--cta">
   <div class="container d-flex justify-content-center align-items-center">
     <div class="row">
       <div class="col-12 text-center">

--- a/layouts/partials/showcase.html
+++ b/layouts/partials/showcase.html
@@ -1,5 +1,12 @@
-<section id="showcase" class="rad-showcase rad-showcase--index rad-animation-group rad-fade-down">
+{{/*
+  sectionId: Optional argument to override the default HTML id for this section. If not provided, the default id is used. */}}
+{{ $sectionId := "showcase" }}
+{{ with .Get "sectionId" }}
+  {{ $sectionId = . }}
+{{ end }}
+<section id="{{ $sectionId }}" class="rad-showcase rad-showcase--index rad-animation-group rad-fade-down">
   <div id="main-content">
+
     {{- $contextType := printf "%T" . -}}
     {{- $isShortcode := (eq $contextType "*hugolib.ShortcodeWithPage") -}}
     {{- $inner := (.Scratch.Get "Inner") -}}

--- a/layouts/partials/showcase.html
+++ b/layouts/partials/showcase.html
@@ -4,7 +4,8 @@
 {{ with .Get "sectionId" }}
   {{ $sectionId = . }}
 {{ end }}
-<section id="{{ $sectionId }}" class="rad-showcase rad-showcase--index rad-animation-group rad-fade-down">
+
+<section {{if $sectionId}} id="{{ $sectionId }}"{{end}} class="rad-showcase rad-showcase--index rad-animation-group rad-fade-down">
   <div id="main-content">
 
     {{- $contextType := printf "%T" . -}}

--- a/layouts/partials/testimonial.html
+++ b/layouts/partials/testimonial.html
@@ -20,7 +20,14 @@
   {{- $testimonials = $testimonials | lang.Merge (where $baseLangSite.RegularPages.ByDate "Type" "testimonial") -}}
 {{- end -}}
 
-<section id="testimonial" class="section rad-animation-group section--border-bottom">
+{{/*
+  sectionId: Optional argument to override the default HTML id for this section. If not provided, the default id is used. */}}
+{{ $sectionId := "testimonial" }}
+{{ with .Get "sectionId" }}
+  {{ $sectionId = . }}
+{{ end }}
+
+<section id="{{ $sectionId }}" class="section rad-animation-group section--border-bottom">
     <div class="container">
     {{/* 
     When passed from a shortcode, the context type is *hugolib.ShortcodeWithPage. 

--- a/layouts/partials/testimonial.html
+++ b/layouts/partials/testimonial.html
@@ -27,7 +27,7 @@
   {{ $sectionId = . }}
 {{ end }}
 
-<section id="{{ $sectionId }}" class="section rad-animation-group section--border-bottom">
+<section {{if $sectionId}} id="{{ $sectionId }}"{{end}} class="section rad-animation-group section--border-bottom">
     <div class="container">
     {{/* 
     When passed from a shortcode, the context type is *hugolib.ShortcodeWithPage. 

--- a/layouts/shortcodes/experience-list.html
+++ b/layouts/shortcodes/experience-list.html
@@ -1,3 +1,10 @@
+{{/*
+  sectionId: Optional argument to override the default HTML id for this section. If not provided, the default id is used. */}}
+{{ $sectionId := "experience-list-shortcode" }}
+{{ with .Get "sectionId" }}
+  {{ $sectionId = . }}
+{{ end }}
+
 {{ $padding := .Get "padding" }}
 {{ $title := .Get "title" | default "" }}
 {{ $containerClass := "" }}
@@ -5,7 +12,7 @@
     {{ $containerClass = "container" }}
 {{ end }}
 
-<section id="experience-list-shortcode" class="section-experience section section--border-bottom rad-animation-group flex-grow-1 {{ $containerClass }}">
+<section id="{{ $sectionId }}" class="section-experience section section--border-bottom rad-animation-group flex-grow-1 {{ $containerClass }}">
     <div class="row flex-column-reverse flex-md-row rad-fade-down">
         <div class="experience-list col-12 mt-5 mt-sm-0">
             {{ if $title }}

--- a/layouts/shortcodes/experience-list.html
+++ b/layouts/shortcodes/experience-list.html
@@ -12,7 +12,7 @@
     {{ $containerClass = "container" }}
 {{ end }}
 
-<section id="{{ $sectionId }}" class="section-experience section section--border-bottom rad-animation-group flex-grow-1 {{ $containerClass }}">
+<section {{if $sectionId}} id="{{ $sectionId }}"{{end}} class="section-experience section section--border-bottom rad-animation-group flex-grow-1 {{ $containerClass }}">
     <div class="row flex-column-reverse flex-md-row rad-fade-down">
         <div class="experience-list col-12 mt-5 mt-sm-0">
             {{ if $title }}

--- a/layouts/shortcodes/link.html
+++ b/layouts/shortcodes/link.html
@@ -4,6 +4,6 @@
   href="{{ $url | absURL }}"
   target="_blank"
   rel="noopener noreferrer"
-  aria-label="{{ $icon }}"
-  ><i class="icon-{{ $icon }}"></i
-></a>
+  {{ if $icon }}aria-label="{{ $icon }}"{{ end }}
+  >{{ if $icon }}<i class="icon-{{ $icon }}"></i>{{ end }}
+</a>

--- a/layouts/shortcodes/platform-links.html
+++ b/layouts/shortcodes/platform-links.html
@@ -1,6 +1,10 @@
 {{/* layouts/shortcodes/platform-links.html */}}
 
-<div class="container">
+{{ $sectionId := "" }}
+{{ with .Get "sectionId" }}
+  {{ $sectionId = . }}
+{{ end }}
+<div class="container" id="{{ $sectionId }}">
   <div class="row platform-links shortcode">
     <div class="col-12">{{ .Inner }}</div>
   </div>

--- a/layouts/shortcodes/platform-links.html
+++ b/layouts/shortcodes/platform-links.html
@@ -4,7 +4,7 @@
 {{ with .Get "sectionId" }}
   {{ $sectionId = . }}
 {{ end }}
-<div class="container" id="{{ $sectionId }}">
+<div class="container"{{ if $sectionId }} id="{{ $sectionId }}"{{ end }}>
   <div class="row platform-links shortcode">
     <div class="col-12">{{ .Inner }}</div>
   </div>

--- a/layouts/shortcodes/text-section.html
+++ b/layouts/shortcodes/text-section.html
@@ -23,7 +23,7 @@
     {{ $columnClass = printf "%s %s" $columnClass "text-center" }}
 {{ end }}
 
-<section id="{{ $sectionId }}" class="section section--border-bottom rad-animation-group {{ $paddingClass }}">
+<section {{if $sectionId}} id="{{ $sectionId }}"{{end}} class="section section--border-bottom rad-animation-group {{ $paddingClass }}">
     <div class="{{ $containerClass }}">
         <div class="row rad-fade-down">
             <div class="{{ $columnClass }}">

--- a/layouts/shortcodes/text-section.html
+++ b/layouts/shortcodes/text-section.html
@@ -1,6 +1,6 @@
 {{/*
   sectionId: Optional argument to override the default HTML id for this section. If not provided, the default id is used. */}}
-{{ $sectionId := "text-section" }}
+{{ $sectionId := "" }}
 {{ with .Get "sectionId" }}
   {{ $sectionId = . }}
 {{ end }}

--- a/layouts/shortcodes/text-section.html
+++ b/layouts/shortcodes/text-section.html
@@ -1,3 +1,10 @@
+{{/*
+  sectionId: Optional argument to override the default HTML id for this section. If not provided, the default id is used. */}}
+{{ $sectionId := "text-section" }}
+{{ with .Get "sectionId" }}
+  {{ $sectionId = . }}
+{{ end }}
+
 {{ $title := .Get "title" | default "" }}
 {{ $subtitle := .Get "subtitle" | default "" }}
 {{ $padding := .Get "padding" | default "true" }}
@@ -16,7 +23,7 @@
     {{ $columnClass = printf "%s %s" $columnClass "text-center" }}
 {{ end }}
 
-<section class="section section--border-bottom rad-animation-group {{ $paddingClass }}">
+<section id="{{ $sectionId }}" class="section section--border-bottom rad-animation-group {{ $paddingClass }}">
     <div class="{{ $containerClass }}">
         <div class="row rad-fade-down">
             <div class="{{ $columnClass }}">

--- a/tests/e2e/language-switch.spec.ts
+++ b/tests/e2e/language-switch.spec.ts
@@ -68,8 +68,8 @@ test.describe('Language switching functionality', () => {
   test('section IDs are translated in Spanish and French', async ({ page }) => {
     // Spanish
     await page.goto(`${BASE_URL}/es/`);
-    await expect(page.locator('#seccion-destacada')).toBeVisible();
-    await expect(page.locator('#enlaces-plataforma')).toBeVisible();
+    await expect(page.locator('#sobre-mi')).toBeVisible();
+    await expect(page.locator('#social')).toBeVisible();
     await expect(page.locator('#sobre-mi')).toBeVisible();
     await expect(page.locator('#formacion-academica')).toBeVisible();
     await expect(page.locator('#experiencia-laboral')).toBeVisible();

--- a/tests/e2e/language-switch.spec.ts
+++ b/tests/e2e/language-switch.spec.ts
@@ -64,4 +64,26 @@ test.describe('Language switching functionality', () => {
     await expect(page.locator('html')).toHaveAttribute('lang', 'fr');
     await expect(page.getByText('Langue').last()).toBeVisible();
   });
+
+  test('section IDs are translated in Spanish and French', async ({ page }) => {
+    // Spanish
+    await page.goto(`${BASE_URL}/es/`);
+    await expect(page.locator('#seccion-destacada')).toBeVisible();
+    await expect(page.locator('#enlaces-plataforma')).toBeVisible();
+    await expect(page.locator('#sobre-mi')).toBeVisible();
+    await expect(page.locator('#formacion-academica')).toBeVisible();
+    await expect(page.locator('#experiencia-laboral')).toBeVisible();
+    await expect(page.locator('#trabajo')).toBeVisible();
+    await expect(page.locator('#testimonios')).toBeVisible();
+
+    // French
+    await page.goto(`${BASE_URL}/fr/`);
+    await expect(page.locator('#section-vedette')).toBeVisible();
+    await expect(page.locator('#liens-plateforme')).toBeVisible();
+    await expect(page.locator('#a-propos')).toBeVisible();
+    await expect(page.locator('#formation-academique')).toBeVisible();
+    await expect(page.locator('#experience-professionnelle')).toBeVisible();
+    await expect(page.locator('#travail')).toBeVisible();
+    await expect(page.locator('#temoignages')).toBeVisible();
+  });
 });

--- a/tests/e2e/search.spec.ts
+++ b/tests/e2e/search.spec.ts
@@ -55,7 +55,7 @@ test.describe('Search functionality', () => {
     await page.waitForTimeout(500);
     
     // Verify we have at least one result
-    await expect(page.locator('#search-results div[id^="summary-"]')).toBeVisible();
+    await expect(page.locator('#search-results div[id^="summary-"]').first()).toBeVisible();
     
     // Now clear the search box
     await page.locator('#search-query').fill('');


### PR DESCRIPTION
Implements #284 

This new feature allows for translating the HTML `id`s used in the template, effectively allowing for translating the `#section` slugs in the translated content. 

This pull request introduces a new `sectionId` parameter across multiple shortcodes and layout files to allow customization of HTML section IDs. The changes improve flexibility by enabling users to override default section IDs with custom values. Below is a summary of the most important changes grouped by theme.

A new e2e test is added as well. 

### Documentation Updates:
* Updated `exampleSite/content/blog/shortcodes.md` to document the new `sectionId` parameter for various shortcodes, including `education-list`, `experience-list`, `platform-links`, `newsletter-section`, and others. This parameter is optional and falls back to default IDs if not provided. [[1]](diffhunk://#diff-dfbe542224f4c852fc0ff4cc9191bdd8bb40529f151d921ece67146a27bf1b99R36-R52) [[2]](diffhunk://#diff-dfbe542224f4c852fc0ff4cc9191bdd8bb40529f151d921ece67146a27bf1b99R66-R71) [[3]](diffhunk://#diff-dfbe542224f4c852fc0ff4cc9191bdd8bb40529f151d921ece67146a27bf1b99L84-R96) [[4]](diffhunk://#diff-dfbe542224f4c852fc0ff4cc9191bdd8bb40529f151d921ece67146a27bf1b99R130-R131) [[5]](diffhunk://#diff-dfbe542224f4c852fc0ff4cc9191bdd8bb40529f151d921ece67146a27bf1b99L131-R140) [[6]](diffhunk://#diff-dfbe542224f4c852fc0ff4cc9191bdd8bb40529f151d921ece67146a27bf1b99R162) [[7]](diffhunk://#diff-dfbe542224f4c852fc0ff4cc9191bdd8bb40529f151d921ece67146a27bf1b99R173) [[8]](diffhunk://#diff-dfbe542224f4c852fc0ff4cc9191bdd8bb40529f151d921ece67146a27bf1b99R183)

### Content Updates:
* Added `sectionId` values in `exampleSite/content/home/home.es.md` and `exampleSite/content/home/home.fr.md` for various sections like `platform-links`, `education-list`, `experience-section`, and others. These changes ensure consistent use of the new parameter in multilingual content. [[1]](diffhunk://#diff-7ba82588723b2d6b0e21d91065a040caaf4cbfd815ea621df0e3146d9bc1ebbdR14-R17) [[2]](diffhunk://#diff-7ba82588723b2d6b0e21d91065a040caaf4cbfd815ea621df0e3146d9bc1ebbdR50-R55) [[3]](diffhunk://#diff-7ba82588723b2d6b0e21d91065a040caaf4cbfd815ea621df0e3146d9bc1ebbdR67) [[4]](diffhunk://#diff-7ba82588723b2d6b0e21d91065a040caaf4cbfd815ea621df0e3146d9bc1ebbdL73-R82) [[5]](diffhunk://#diff-41a5f65708652bdd7f2c044883d8c2e0918c5b25ac42c26138e7e4002d610d1aR14-R17) [[6]](diffhunk://#diff-41a5f65708652bdd7f2c044883d8c2e0918c5b25ac42c26138e7e4002d610d1aR49-R54) [[7]](diffhunk://#diff-41a5f65708652bdd7f2c044883d8c2e0918c5b25ac42c26138e7e4002d610d1aR66-R79)

### Layout Enhancements:
* Added support for the `sectionId` parameter in layout files like `about.html`, `client-and-work.html`, `contact.html`, `education.html`, `experience.html`, `newsletter.html`, `showcase.html`, and `testimonial.html`. These updates ensure that the `sectionId` parameter is used to dynamically set the HTML `id` attribute for sections. [[1]](diffhunk://#diff-0d451e8ef7e268e910d834325a97fb00e6cbddd2b97d49fb9e8aad962a90e21fR55-R62) [[2]](diffhunk://#diff-bf3fa1d26f7f99ebb6f8551ce678fd1b7d76c68e643d9e875ab08c4140243e9dL33-R40) [[3]](diffhunk://#diff-b7c02863ce1a51100662bb4f2f330859013b829bee5d9f5eadefeaaf98db093bR4-R10) [[4]](diffhunk://#diff-b7c02863ce1a51100662bb4f2f330859013b829bee5d9f5eadefeaaf98db093bL82-R89) [[5]](diffhunk://#diff-20d6fac431effe9143849373d86326ed6b933cab6ed32cad76371ef8117f3efdR4-R10) [[6]](diffhunk://#diff-20d6fac431effe9143849373d86326ed6b933cab6ed32cad76371ef8117f3efdL14-R21) [[7]](diffhunk://#diff-72dc0628c6edef5024993b5771a79927e95010adab70da325535d7a167a854a5L4-R13) [[8]](diffhunk://#diff-702739e9543119d794e1d84f3de7ac30782f27abcc29dda6c0117854de710b0aL18-R25) [[9]](diffhunk://#diff-c63550c62f305dd1c40a94c6047acafaa6e0488207ef5e5b29189c86bf97e73aL1-R9) [[10]](diffhunk://#diff-3e52adf57e36c747d003630397c02ddeede4e27d05173cc1f1f82beca1e52b00L23-R30)

### Shortcode Enhancements:
* Added support for the `sectionId` parameter in shortcode files like `experience-list.html` and `text-section.html`. These changes allow users to customize section IDs when using these shortcodes. [[1]](diffhunk://#diff-8d0813336d3fa31088b3e3153e3baed78113c401069846f1dfad483a5aab6cd0R1-R15) [[2]](diffhunk://#diff-8ca21a50c6cc87986ed382491b26cf2bc729c81c5b5638a6eab0e22e9c973486R1-R7)