### PR TITLE
[#293] Button styling for keyboard tabbing

### DIFF
--- a/assets/scss/adritian.scss
+++ b/assets/scss/adritian.scss
@@ -281,7 +281,6 @@ footer_links .nav-item .nav-link::after {
     background-color: #181818;
   }
 
-
   @media (min-width: 992px) {
     .header .navbar .nav-item:hover .nav-link::after {
       background-color: #fff;
@@ -386,7 +385,7 @@ footer_links .nav-item .nav-link::after {
     color: #fff;
     border-color: #fff;
   }
-  .btn:focus-visible{
+  .btn:focus-visible {
     color: black;
     background-color: white;
     box-shadow: 0 0 0 0.2rem $primary;

--- a/assets/scss/adritian.scss
+++ b/assets/scss/adritian.scss
@@ -386,6 +386,11 @@ footer_links .nav-item .nav-link::after {
     color: #fff;
     border-color: #fff;
   }
+  .btn:focus-visible{
+    color: black;
+    background-color: white;
+    box-shadow: 0 0 0 0.2rem $primary;
+  }
   .btn-frameless.disabled,
   .btn-frameless.focus,
   .btn-frameless:disabled,

--- a/assets/scss/adritian.scss
+++ b/assets/scss/adritian.scss
@@ -50,6 +50,10 @@ h6 {
   margin-bottom: 8px;
 }
 
+.btn:focus-visible{
+  box-shadow: 0 0 0 0.2rem $primary;
+}
+
 @media (min-width: 992px) {
   .h1,
   .h2,


### PR DESCRIPTION
Resolves #293 

The styles are consistent now for light and dark modes.

![2025-05-08 11 16 15](https://github.com/user-attachments/assets/dbba4882-1e43-4f31-b7c0-57156e33af6c)
![2025-05-08 11 19 30](https://github.com/user-attachments/assets/122aa400-5ffe-419b-ad3e-66090b4f12c5)
