### PR TITLE
feat(page-transition): implement page transition effect with overlay

### DIFF
--- a/assets/js/page-transition.js
+++ b/assets/js/page-transition.js
@@ -1,0 +1,44 @@
+// Wait for the DOM content to be fully loaded
+document.addEventListener('DOMContentLoaded', function() {
+  // Create the overlay element if it doesn't exist
+  if (!document.querySelector('.transition-overlay')) {
+    const overlay = document.createElement('div');
+    overlay.className = 'transition-overlay';
+    document.body.appendChild(overlay);
+  }
+  
+  // Find all internal links
+  document.querySelectorAll('a').forEach(function(link) {
+    // Only handle links to the same site that aren't anchor links
+    if (link.hostname === window.location.hostname && 
+        !link.hasAttribute('target') && 
+        !link.getAttribute('href').startsWith('#')) {
+        
+      link.addEventListener('click', function(e) {
+        // Don't handle special clicks (modifier keys)
+        if (e.ctrlKey || e.shiftKey || e.metaKey || e.altKey) {
+          return;
+        }
+        
+        e.preventDefault();
+        const destination = link.href;
+        
+        // Add active class to trigger the overlay
+        document.body.classList.add('transition-active');
+        
+        // Navigate after a slight delay
+        setTimeout(function() {
+          window.location.href = destination;
+        }, 300);
+      });
+    }
+  });
+});
+
+// If someone navigates back/forward, we need to hide the overlay
+window.addEventListener('pageshow', function(event) {
+  // This works for both fresh loads and back-forward cache
+  if (document.body.classList.contains('transition-active')) {
+    document.body.classList.remove('transition-active');
+  }
+}); 

--- a/assets/scss/_page-transition.scss
+++ b/assets/scss/_page-transition.scss
@@ -1,0 +1,22 @@
+.transition-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: #fff;
+  z-index: 9999;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+}
+
+/* For dark mode */
+html[data-bs-theme="dark"] .transition-overlay {
+  background-color: #181818;
+}
+
+.transition-active .transition-overlay {
+  opacity: 1;
+  pointer-events: all;
+} 

--- a/assets/scss/adritian.scss
+++ b/assets/scss/adritian.scss
@@ -7,6 +7,7 @@
 @import "experience";
 @import "print";
 @import "search";
+@import "page-transition";
 
 /** main style **/
 .header .navbar-brand span:first-child {

--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -355,6 +355,10 @@ header = false
 mobileHeader = false
 ## by default we allow override AND automatic selection
 
+# Page transition settings
+[params.pageTransition]
+enabled = true  # Set to false to disable the page fade transition effect
+
 [params.blog]
 layout = "sidebar-right"     # options: default (no sidebar), sidebar, sidebar-right
 sidebarWidth = "25"    # percentage width of the sidebar

--- a/layouts/partials/base-foot.html
+++ b/layouts/partials/base-foot.html
@@ -33,3 +33,14 @@
 {{- if $vercelAnalytics }} 
 <script defer src="/_vercel/insights/script.js"></script>
 {{- end }}
+
+{{/* 
+  Page transition script is temporarily disabled for debugging
+*/}}
+{{- if not (isset .Site.Params "pageTransition") -}}
+  {{- /* Default behavior: load the script if not specified */ -}}
+  <script defer src='{{ "js/page-transition.js" | absURL }}'></script>
+{{- else if .Site.Params.pageTransition.enabled -}}
+  {{- /* Load the script if explicitly enabled */ -}}
+  <script defer src='{{ "js/page-transition.js" | absURL }}'></script>
+{{- end -}}


### PR DESCRIPTION
There are cases where the pages load so fast across URLs that there's a blink in the browser. Especially as hugo's static pages load really fast, and the theme too.


This pull request introduces a page transition feature to enhance user experience with smooth fade effects when navigating between pages. The changes include JavaScript for managing the transitions, SCSS for styling the overlay, configuration updates for enabling/disabling the feature, and integration into the site layout.


**Before**

![2025-05-09 21 24 39](https://github.com/user-attachments/assets/d55e7470-f8aa-49ec-b7a6-46492c3978f7)


**After**

![2025-05-09 21 25 56](https://github.com/user-attachments/assets/f9cb06e2-e5f3-4a0a-a48e-97426910068c)




### Page Transition Feature Implementation:

* [`assets/js/page-transition.js`](diffhunk://#diff-bd5da9e0a48d4a70be57d4570e4cad3cfafe2aa54ee0425b126717a287eb2fdeR1-R44): Added a script to handle page transitions with a fade effect. It creates an overlay, listens for internal link clicks, and applies a transition effect before navigation. It also ensures the overlay is reset when navigating back/forward.

* [`assets/scss/_page-transition.scss`](diffhunk://#diff-a2fc9935ce4914fd80fa0483118a4e1f493f9f8743befbee1648c67e09921ddeR1-R22): Added styles for the transition overlay, including support for light and dark modes. The overlay fades in and out during transitions.

### Integration with Site:

* [`assets/scss/adritian.scss`](diffhunk://#diff-d2657e38837f7230f8c0a04667ed5c3c2241e81931889bf9c9bc59013903059dR10): Imported the `page-transition` SCSS file to include the new styles in the main stylesheet.

* [`exampleSite/hugo.toml`](diffhunk://#diff-279bd0658bb2e85fd1870d43ecae3032643d15e5f98e39eaf45252346917b3e8R358-R361): Added a configuration option under `[params.pageTransition]` to enable or disable the page transition feature.

* [`layouts/partials/base-foot.html`](diffhunk://#diff-4b479d343bb145a5299f9190cb0145e61e3b06a058592653a627bdad221cb454R36-R46): Updated the footer template to conditionally load the page transition script based on the configuration in `hugo.toml`.