### PR TITLE
feat(theme): implement theme initialization and prevent flash on load

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -2,6 +2,13 @@
 
 This documentation is meant to help you upgrade across versions, when potentially breaking changes are introduced.
 
+## v1.7.19
+
+Adding a new page transition effect.
+The new effect is applied to all pages, and is triggered when navigating through the site. It can be disabled in the `config.toml` file, under the `params.pageTransition` section.
+
+By default, the effect is enabled.
+
 ## v1.7.12
 
 __Introducing 🔎Search__

--- a/assets/js/color-modes.js
+++ b/assets/js/color-modes.js
@@ -4,6 +4,23 @@
  * Licensed under the Creative Commons Attribution 3.0 Unported License.
  */
 
+// Immediately set the theme before the page renders to prevent flash
+(function() {
+  const getStoredTheme = () => localStorage.getItem('theme')
+  const getPreferredTheme = () => {
+    const storedTheme = getStoredTheme()
+    if (storedTheme) {
+      return storedTheme
+    }
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+  }
+
+  // Apply the theme immediately to prevent flash
+  const theme = getPreferredTheme()
+  document.documentElement.setAttribute('data-bs-theme', theme)
+})();
+
+// Main theme functionality
 (() => {
     'use strict'
 

--- a/assets/js/color-modes.js
+++ b/assets/js/color-modes.js
@@ -6,18 +6,8 @@
 
 // Immediately set the theme before the page renders to prevent flash
 (function() {
-  const getStoredTheme = () => localStorage.getItem('theme')
-  const getPreferredTheme = () => {
-    const storedTheme = getStoredTheme()
-    if (storedTheme) {
-      return storedTheme
-    }
-    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
-  }
-
-  // Apply the theme immediately to prevent flash
-  const theme = getPreferredTheme()
-  document.documentElement.setAttribute('data-bs-theme', theme)
+  const theme = getPreferredTheme();
+  setTheme(theme);
 })();
 
 // Main theme functionality

--- a/assets/scss/_theme-init.scss
+++ b/assets/scss/_theme-init.scss
@@ -1,0 +1,19 @@
+/* Preload styles to prevent theme flash */
+:root {
+  &[data-bs-theme=dark] {
+    color-scheme: dark;
+    --bs-body-color: #fff;
+    --bs-body-bg: #181818;
+  }
+  
+  &[data-bs-theme=light] {
+    color-scheme: light;
+    --bs-body-color: #000;
+    --bs-body-bg: #fff;
+  }
+}
+
+/* Ensure smooth transition when switching themes */
+html {
+  transition: background-color 0.15s ease-in-out;
+} 

--- a/assets/scss/adritian.scss
+++ b/assets/scss/adritian.scss
@@ -1,4 +1,7 @@
+@charset "UTF-8";
+
 @import "variables";
+@import "theme-init";
 @import "bootstrap/bootstrap";
 @import "navbar";
 @import "menu";

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -94,6 +94,20 @@
 
 <!-- printed only it not disabled -->
 {{- if not .Site.Params.colorTheme.auto.disable }}
+  {{/* Inline script to prevent theme flash */}}
+  <script>
+    (function() {
+      const getStoredTheme = () => localStorage.getItem('theme');
+      const getPreferredTheme = () => {
+        const storedTheme = getStoredTheme();
+        if (storedTheme) {
+          return storedTheme;
+        }
+        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+      };
+      document.documentElement.setAttribute('data-bs-theme', getPreferredTheme());
+    })();
+  </script>
   {{- $colorModesScript := resources.Get "js/color-modes.js" }}
   {{- if hugo.IsProduction }}
     {{- $colorModesScript = $colorModesScript | resources.Minify | resources.Fingerprint }}


### PR DESCRIPTION
Added a new SCSS file for theme initialization to preload styles and prevent theme flash during page load - when using the dark theme. Updated JavaScript to set the theme immediately based on user preferences or stored settings. Enhanced the head template to include inline script for theme handling.