### PR TITLE
feat(theme): enhance theme transition handling and prevent flash

### DIFF
--- a/assets/js/color-modes.js
+++ b/assets/js/color-modes.js
@@ -4,13 +4,6 @@
  * Licensed under the Creative Commons Attribution 3.0 Unported License.
  */
 
-// Immediately set the theme before the page renders to prevent flash
-(function() {
-  const theme = getPreferredTheme();
-  setTheme(theme);
-})();
-
-// Main theme functionality
 (() => {
     'use strict'
 
@@ -29,16 +22,27 @@
     }
   
     function setTheme(theme) {
+      // Apply a transition class before changing theme
+      document.documentElement.classList.add('theme-transition');
+      
+      // Set the new theme
       if (theme === 'auto') {
-        document.documentElement.setAttribute(
-          'data-bs-theme',
-          window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
-        )
+        const isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        document.documentElement.setAttribute('data-bs-theme', isDark ? 'dark' : 'light');
+        // Store the actual value for smoother transitions
+        document.documentElement.setAttribute('data-theme-auto', 'true');
       } else {
-        document.documentElement.setAttribute('data-bs-theme', theme)
+        document.documentElement.setAttribute('data-bs-theme', theme);
+        document.documentElement.removeAttribute('data-theme-auto');
       }
+      
+      // Remove the transition class after a short delay
+      setTimeout(() => {
+        document.documentElement.classList.remove('theme-transition');
+      }, 300);
     }
   
+    // Apply theme immediately to prevent flash
     setTheme(getPreferredTheme())
   
     const showActiveTheme = (theme, focus = false) => {
@@ -70,10 +74,11 @@
       }
     }
   
-    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
+    // Listen for system preference changes
+    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', event => {
       const storedTheme = getStoredTheme()
-      if (storedTheme !== 'light' && storedTheme !== 'dark') {
-        setTheme(getPreferredTheme())
+      if (storedTheme === 'auto' || (!storedTheme && document.documentElement.getAttribute('data-theme-auto') === 'true')) {
+        setTheme('auto')
       }
     })
   

--- a/assets/scss/_theme-init.scss
+++ b/assets/scss/_theme-init.scss
@@ -15,5 +15,24 @@
 
 /* Ensure smooth transition when switching themes */
 html {
-  transition: background-color 0.15s ease-in-out;
+  transition: background-color 0.2s ease-in-out, color 0.2s ease-in-out;
+}
+
+/* Prevent flicker on elements that change color with theme */
+body, p, h1, h2, h3, h4, h5, h6, a {
+  transition: color 0.2s ease-in-out;
+}
+
+/* Applied during theme changes to ensure smooth transitions */
+html.theme-transition,
+html.theme-transition *,
+html.theme-transition *:before,
+html.theme-transition *:after {
+  transition: all 0s !important;
+  -webkit-transition: all 0s !important;
+}
+
+/* Specific auto mode handling - prevents flash when system preference changes */
+html[data-theme-auto="true"] {
+  transition: background-color 0.3s ease-in-out, color 0.3s ease-in-out;
 } 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -96,16 +96,22 @@
 {{- if not .Site.Params.colorTheme.auto.disable }}
   {{/* Inline script to prevent theme flash */}}
   <script>
+    // Simple script to set initial theme to prevent flash
     (function() {
-      const getStoredTheme = () => localStorage.getItem('theme');
-      const getPreferredTheme = () => {
-        const storedTheme = getStoredTheme();
-        if (storedTheme) {
-          return storedTheme;
+      const storedTheme = localStorage.getItem('theme');
+      if (storedTheme) {
+        if (storedTheme === 'auto') {
+          const isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+          document.documentElement.setAttribute('data-bs-theme', isDark ? 'dark' : 'light');
+          document.documentElement.setAttribute('data-theme-auto', 'true');
+        } else {
+          document.documentElement.setAttribute('data-bs-theme', storedTheme);
         }
-        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-      };
-      document.documentElement.setAttribute('data-bs-theme', getPreferredTheme());
+      } else {
+        const isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        document.documentElement.setAttribute('data-bs-theme', isDark ? 'dark' : 'light');
+        document.documentElement.setAttribute('data-theme-auto', 'true');
+      }
     })();
   </script>
   {{- $colorModesScript := resources.Get "js/color-modes.js" }}


### PR DESCRIPTION
Refactored theme initialization in JavaScript to include a transition effect during theme changes. Updated SCSS for smoother transitions and added handling for auto mode to prevent flicker. Improved inline script in the head template to set the initial theme based on user preferences.

Fixing a bug introduced in https://github.com/zetxek/adritian-free-hugo-theme/pull/298