### PR TITLE
Update hugo version in automated workflows (0.147.2)

### DIFF
--- a/.github/workflows/test-example-site.yml
+++ b/.github/workflows/test-example-site.yml
@@ -22,7 +22,7 @@ jobs:
   prepare:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.136.2
+      HUGO_VERSION: 0.147.2
     steps:
       - name: Install Hugo CLI
         run: |
@@ -67,7 +67,7 @@ jobs:
     needs: prepare
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.136.2
+      HUGO_VERSION: 0.147.2
     steps:
       - name: Install Hugo CLI
         run: |
@@ -128,7 +128,7 @@ jobs:
     needs: prepare
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.136.2
+      HUGO_VERSION: 0.147.2
     steps:
       - name: Install Hugo CLI
         run: |

--- a/.github/workflows/update-demo-pr.yml
+++ b/.github/workflows/update-demo-pr.yml
@@ -82,7 +82,7 @@ jobs:
     env:
       SOURCE_BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       PR_NUMBER: ${{ github.event.number }}
-      HUGO_VERSION: 0.141.0
+      HUGO_VERSION: 0.147.2
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Updating the workflows in the repo to [`0.147.2`](https://discourse.gohugo.io/t/hugo-0-147-2-released/54651).