### PR TITLE
Add text alignment option to about section shortcodes

### DIFF
--- a/exampleSite/content/blog/shortcodes.md
+++ b/exampleSite/content/blog/shortcodes.md
@@ -129,6 +129,8 @@ The shortcodes can be customized with different arguments:
 
     - `imgScale` - Specifies the scale used for the image (for example, `0.5` if the high resolution image is double the size of the smaller one) This is only considered if neither imgWidth nor imgHeight is used.
 
+    - `text_align` - Controls the vertical alignment of the text content relative to the image. Accepts "center" (default), "top", or "bottom".
+
     - Primary Button Arguments
       - `button1_enable` - Boolean value to show or hide the primary button. Defaults to the value from site data.
 

--- a/exampleSite/content/home/home.md
+++ b/exampleSite/content/home/home.md
@@ -47,6 +47,7 @@ draft = false
     button_url="/skills"
     imgSrc="images/about/user-picture.png"
     imgScale="0.5"
+    text_align="center"
  >}}
 
 {{< education-list

--- a/layouts/partials/about.html
+++ b/layouts/partials/about.html
@@ -36,6 +36,17 @@
 {{ end }}
 
 {{/* ---------------------------------------------------------------------------
+     TEXT ALIGNMENT
+     --------------------------------------------------------------------------- */}}
+{{- $textAlign := "center" -}}
+
+{{- if $isShortcode }}
+  {{- $textAlign = .Get "text_align" | default "center" -}}
+{{ else }}
+  {{- $textAlign = .Site.Data.homepage.about.text_align | default "center" -}}
+{{ end }}
+
+{{/* ---------------------------------------------------------------------------
      BUTTON
      --------------------------------------------------------------------------- */}}
 {{- $btnURL := "" -}}
@@ -65,7 +76,7 @@
       <div class="about__profile-picture col-12 col-md-6">
         {{ partial "lazypicture" (dict "src" $imgSrc "width" $imgWidth "height" $imgHeight "scale" $imgScale "class" "image-left-overflow")}}
       </div>
-      <div class="col-12 col-md-6 my-auto my-auto">
+      <div class="col-12 col-md-6{{ if eq $textAlign "center" }} my-auto{{ else if eq $textAlign "top" }} align-self-start{{ else if eq $textAlign "bottom" }} align-self-end{{ end }}">
         <h1>{{ $title }}</h1>
         <div class="about-me content lead">
           {{ $content }}


### PR DESCRIPTION
Implements #189 

Introduce a `text_align` parameter to control the vertical alignment of text in the about section, enhancing the customization options for shortcodes. Update documentation accordingly.

<img width="1444" alt="image" src="https://github.com/user-attachments/assets/aab4130c-f44b-43db-a29e-b7627d713793" />
