### PR TITLE
Remove page-transition script loading

### DIFF
--- a/assets/js/page-transition.js
+++ b/assets/js/page-transition.js
@@ -1,5 +1,5 @@
 // Wait for the DOM content to be fully loaded
-document.addEventListener('DOMContentLoaded', function() {
+document.addEventListener('DOMContentLoaded', () => {
   // Create the overlay element if it doesn't exist
   if (!document.querySelector('.transition-overlay')) {
     const overlay = document.createElement('div');
@@ -8,13 +8,25 @@ document.addEventListener('DOMContentLoaded', function() {
   }
   
   // Find all internal links
-  document.querySelectorAll('a').forEach(function(link) {
+  for (const link of document.querySelectorAll('a')) {
+    const href = link.getAttribute('href');
+    
+    // Skip if no href
+    if (!href) continue;
+    
+    // Skip anchor links (both relative #section and absolute with fragments)
+    if (href.startsWith('#') || 
+        (link.hostname === window.location.hostname && 
+         link.pathname === window.location.pathname && 
+         link.hash)) {
+      continue;
+    }
+    
     // Only handle links to the same site that aren't anchor links
     if (link.hostname === window.location.hostname && 
-        !link.hasAttribute('target') && 
-        !link.getAttribute('href').startsWith('#')) {
+        !link.hasAttribute('target')) {
         
-      link.addEventListener('click', function(e) {
+      link.addEventListener('click', (e) => {
         // Don't handle special clicks (modifier keys)
         if (e.ctrlKey || e.shiftKey || e.metaKey || e.altKey) {
           return;
@@ -27,18 +39,18 @@ document.addEventListener('DOMContentLoaded', function() {
         document.body.classList.add('transition-active');
         
         // Navigate after a slight delay
-        setTimeout(function() {
+        setTimeout(() => {
           window.location.href = destination;
         }, 300);
       });
     }
-  });
+  }
 });
 
 // If someone navigates back/forward, we need to hide the overlay
-window.addEventListener('pageshow', function(event) {
+window.addEventListener('pageshow', (event) => {
   // This works for both fresh loads and back-forward cache
   if (document.body.classList.contains('transition-active')) {
     document.body.classList.remove('transition-active');
   }
-}); 
+});

--- a/layouts/partials/base-foot.html
+++ b/layouts/partials/base-foot.html
@@ -41,18 +41,3 @@
 {{- if $vercelAnalytics }} 
 <script defer src="/_vercel/insights/script.js"></script>
 {{- end }}
-
-{{/* 
-  Page transition script is temporarily disabled for debugging
-*/}}
-{{- $pageTransitionScript := resources.Get "js/page-transition.js" }}
-{{- if hugo.IsProduction }}
-  {{- $pageTransitionScript = $pageTransitionScript | resources.Minify | resources.Fingerprint }}
-{{- end }}
-{{- if not (isset .Site.Params "pageTransition") -}}
-  {{- /* Default behavior: load the script if not specified */ -}}
-  <script defer src="{{ $pageTransitionScript.Permalink }}"></script>
-{{- else if .Site.Params.pageTransition.enabled -}}
-  {{- /* Load the script if explicitly enabled */ -}}
-  <script defer src="{{ $pageTransitionScript.Permalink }}"></script>
-{{- end -}}


### PR DESCRIPTION
Eliminate the loading of the page-transition script and simplify the event listener for internal links. This change enhances code clarity and performance.