### PR TITLE
#334: increase font weight for bold text

### DIFF
--- a/assets/scss/adritian.scss
+++ b/assets/scss/adritian.scss
@@ -122,6 +122,10 @@ p + p {
   margin-top: -12px;
 }
 
+b, strong{
+  font-weight: 600;
+}
+
 .display-1 {
   font-size: 36px;
   font-weight: 800;


### PR DESCRIPTION
#334 showcased the lack of differenciation of the bold text in some browsers.
This PR increases the weight for the bold text.

After/Before:
<img width="1512" height="943" alt="image" src="https://github.com/user-attachments/assets/89bc8872-1157-42b6-8e95-ebcb8657e62c" />


Bootstrap reference: https://getbootstrap.com/docs/5.2/utilities/text/#font-weight-and-italics

<img width="1512" height="910" alt="image" src="https://github.com/user-attachments/assets/44613293-e3fe-4934-9cb0-fc65ae872fe1" />
