### PR TITLE
refactor: update shortcode alignment parameters

### DIFF
--- a/exampleSite/content/blog/shortcodes.md
+++ b/exampleSite/content/blog/shortcodes.md
@@ -129,7 +129,14 @@ The shortcodes can be customized with different arguments:
 
     - `imgScale` - Specifies the scale used for the image (for example, `0.5` if the high resolution image is double the size of the smaller one) This is only considered if neither imgWidth nor imgHeight is used.
 
-    - `text_align` - Controls the vertical alignment of the text content relative to the image. Accepts "center" (default), "top", or "bottom".
+    - `v_align` - Controls the vertical alignment of the text content relative to the image. Accepts "center" (default), "top", or "bottom".
+    - `text_align` - **Deprecated**: Use `v_align` instead. Maintains backwards compatibility.
+    - `h_align` - Controls the horizontal alignment of the text content. Accepts "left" (default), "center", or "right".
+    
+    **Alignment Examples**:
+    - `v_align="center" h_align="left"` - Text vertically centered, left-aligned (default)
+    - `v_align="top" h_align="center"` - Text at top, horizontally centered
+    - `v_align="bottom" h_align="right"` - Text at bottom, right-aligned
 
     - Primary Button Arguments
       - `button1_enable` - Boolean value to show or hide the primary button. Defaults to the value from site data.

--- a/exampleSite/content/home/home.md
+++ b/exampleSite/content/home/home.md
@@ -47,7 +47,8 @@ draft = false
     button_url="/skills"
     imgSrc="images/about/user-picture.png"
     imgScale="0.5"
-    text_align="center"
+    v_align="center"
+    h_align="left"
  >}}
 
 {{< education-list

--- a/layouts/partials/about.html
+++ b/layouts/partials/about.html
@@ -36,14 +36,19 @@
 {{ end }}
 
 {{/* ---------------------------------------------------------------------------
-     TEXT ALIGNMENT
+     ALIGNMENT
      --------------------------------------------------------------------------- */}}
-{{- $textAlign := "center" -}}
+{{- $vAlign := "center" -}}
+{{- $hAlign := "left" -}}
 
 {{- if $isShortcode }}
-  {{- $textAlign = .Get "text_align" | default "center" -}}
+  {{- /* Support both v_align and text_align for backwards compatibility */ -}}
+  {{- $vAlign = .Get "v_align" | default (.Get "text_align") | default "center" -}}
+  {{- $hAlign = .Get "h_align" | default "left" -}}
 {{ else }}
-  {{- $textAlign = .Site.Data.homepage.about.text_align | default "center" -}}
+  {{- /* Support both v_align and text_align for backwards compatibility */ -}}
+  {{- $vAlign = .Site.Data.homepage.about.v_align | default .Site.Data.homepage.about.text_align | default "center" -}}
+  {{- $hAlign = .Site.Data.homepage.about.h_align | default "left" -}}
 {{ end }}
 
 {{/* ---------------------------------------------------------------------------
@@ -76,7 +81,7 @@
       <div class="about__profile-picture col-12 col-md-6">
         {{ partial "lazypicture" (dict "src" $imgSrc "width" $imgWidth "height" $imgHeight "scale" $imgScale "class" "image-left-overflow")}}
       </div>
-      <div class="col-12 col-md-6{{ if eq $textAlign "center" }} my-auto{{ else if eq $textAlign "top" }} align-self-start{{ else if eq $textAlign "bottom" }} align-self-end{{ end }}">
+      <div class="col-12 col-md-6{{ if eq $vAlign "center" }} my-auto{{ else if eq $vAlign "top" }} align-self-start{{ else if eq $vAlign "bottom" }} align-self-end{{ end }}{{ if eq $hAlign "center" }} text-center{{ else if eq $hAlign "right" }} text-end{{ end }}">
         <h1>{{ $title }}</h1>
         <div class="about-me content lead">
           {{ $content }}


### PR DESCRIPTION
Inspired by the feature request in #189: 

- Renamed `text_align` to `v_align` for vertical alignment and added `h_align` for horizontal alignment.
- Marked `text_align` as deprecated to maintain backwards compatibility.
- Updated examples and documentation to reflect the new alignment parameters.
- Adjusted related template files to utilize the new parameters.
 
<img width="1462" height="799" alt="SCR-20250802-kvlo-2" src="https://github.com/user-attachments/assets/6267247e-3434-4409-b3da-40052e29a0a1" />
<img width="1461" height="783" alt="SCR-20250802-kvib-2" src="https://github.com/user-attachments/assets/25eed31d-1e6a-4441-9a63-1c152576f928" />

<img width="1456" height="834" alt="SCR-20250802-kvob-2" src="https://github.com/user-attachments/assets/999decfe-fe1f-40b9-8227-d773a15710d0" />

