### PR TITLE
Update RTL styles to prevent horizontal scroll on mobile by removing negative margin in showcase section

### DIFF
--- a/assets/scss/_rtl.scss
+++ b/assets/scss/_rtl.scss
@@ -63,7 +63,11 @@ html[dir="rtl"] body {
   .showcase-section {
     .platform-links.shortcode {
       margin-left: 0;
-      margin-right: 0; // Don't use negative margin in RTL as it causes horizontal scroll on mobile
+      
+      // Apply negative margin only on larger screens to prevent horizontal scroll on mobile
+      @media (min-width: 992px) {
+        margin-right: -40px;
+      }
     }
     
     // Mirror showcase image for RTL - the image appears on the left side in RTL

--- a/assets/scss/adritian.scss
+++ b/assets/scss/adritian.scss
@@ -136,8 +136,10 @@ b, strong{
 }
 
 .showcase-section .platform-links.shortcode {
-  /* align to the left margin */
-  margin-left: -40px;
+  /* align to the left margin only on larger screens to prevent horizontal scroll on mobile */
+  @media (min-width: 992px) {
+    margin-left: -40px;
+  }
 }
 
 @media (min-width: 992px) {


### PR DESCRIPTION
This pull request makes a small adjustment to the right-to-left (RTL) stylesheet to improve mobile usability. The negative right margin for `.platform-links.shortcode` inside `.showcase-section` has been removed to prevent unwanted horizontal scrolling on mobile devices.

- Removed negative right margin from `.platform-links.shortcode` in `.showcase-section` to fix horizontal scroll issues in RTL layouts on mobile devices.