### PR TITLE
Add Conductor config

### DIFF
--- a/conductor.json
+++ b/conductor.json
@@ -1,6 +1,6 @@
 {
     "scripts": {
-        "setup": "npm i",
+        "setup": "npm ci",
         "run": "cd examplesSite && hugo serve --themesDir=../"
     }
 }


### PR DESCRIPTION
Adds a Conductor (https://www.conductor.build/) configuration file for setup and local run scripts.

To add Conductor support:
- Run `npm ci`
- Start with `cd examplesSite && hugo serve --themesDir=../` (as defined in `conductor.json`).