### PR TITLE
fix: improve image handling in jsonld schema

### DIFF
--- a/exampleSite/content/blog/test-image-array-format.md
+++ b/exampleSite/content/blog/test-image-array-format.md
@@ -1,0 +1,12 @@
+---
+title: 'Test Post - Images Array Format'
+date: 2025-03-04T10:00:00+00:00
+draft: false
+type: 'blog'
+description: 'Test post to verify images array extraction in JSON-LD schema'
+images:
+  - '/img/blog/test-images-array.png'
+  - '/img/blog/test-images-array-2.png'
+---
+
+This is a test post to verify that the JSON-LD schema correctly extracts the first image from the `images` array format.

--- a/exampleSite/content/blog/test-image-featured-image.md
+++ b/exampleSite/content/blog/test-image-featured-image.md
@@ -1,0 +1,10 @@
+---
+title: 'Test Post - FeaturedImage Parameter'
+date: 2025-03-02T10:00:00+00:00
+draft: false
+type: 'blog'
+description: 'Test post to verify featuredImage parameter extraction in JSON-LD schema'
+featuredImage: '/img/blog/test-featured-image.png'
+---
+
+This is a test post to verify that the JSON-LD schema correctly extracts the image from the `featuredImage` frontmatter parameter.

--- a/exampleSite/content/blog/test-image-no-image.md
+++ b/exampleSite/content/blog/test-image-no-image.md
@@ -1,0 +1,9 @@
+---
+title: 'Test Post - No Image Fallback'
+date: 2025-03-03T10:00:00+00:00
+draft: false
+type: 'blog'
+description: 'Test post to verify site-level image fallback in JSON-LD schema'
+---
+
+This is a test post with no image specified in frontmatter. The JSON-LD schema should fallback to the site-level image configured in hugo.toml.

--- a/exampleSite/content/blog/test-image-yaml-format.md
+++ b/exampleSite/content/blog/test-image-yaml-format.md
@@ -1,0 +1,11 @@
+---
+title: 'Test Post - YAML Image Format'
+date: 2025-03-01T10:00:00+00:00
+draft: false
+type: 'blog'
+description: 'Test post to verify images.featured_image extraction in JSON-LD schema'
+images:
+  featured_image: '/img/blog/test-yaml-format.png'
+---
+
+This is a test post to verify that the JSON-LD schema correctly extracts the image from the `images.featured_image` YAML frontmatter parameter.

--- a/layouts/partials/seo/jsonld.html
+++ b/layouts/partials/seo/jsonld.html
@@ -138,6 +138,10 @@
         {{- if gt (len .) 0 -}}
           {{- $pageImage = index . 0 -}}
         {{- end -}}
+      {{- else -}}
+        {{- with .featured_image -}}
+          {{- $pageImage = . -}}
+        {{- end -}}
       {{- end -}}
     {{- end -}}
   {{- end -}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "barcelona",
+  "name": "adritian-free-hugo-theme",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -309,7 +309,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2046,7 +2045,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -2804,7 +2802,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/tests/e2e/seo.spec.ts
+++ b/tests/e2e/seo.spec.ts
@@ -67,4 +67,68 @@ test('homepage includes canonical, twitter (from params.social), and JSON-LD sit
     expect(blogPosting).toBeTruthy();
     expect(blogPosting?.headline).toBe('New Theme Features Demo');
   });
+
+  test('blog post JSON-LD extracts image from images.featured_image (YAML format)', async ({ page }) => {
+    await page.goto(`${BASE_URL}/blog/test-image-yaml-format/`);
+
+    const jsonLd = await parseJsonLd(page);
+    const blogPosting = jsonLd.find(item => item['@type'] === 'BlogPosting');
+    expect(blogPosting).toBeTruthy();
+    expect(blogPosting?.headline).toBe('Test Post - YAML Image Format');
+    
+    // Verify image is correctly extracted from images.featured_image
+    expect(blogPosting?.image).toBeTruthy();
+    expect(Array.isArray(blogPosting?.image)).toBe(true);
+    const imageArray = blogPosting?.image as string[];
+    expect(imageArray.length).toBeGreaterThan(0);
+    expect(imageArray[0]).toContain('/img/blog/test-yaml-format.png');
+  });
+
+  test('blog post JSON-LD extracts image from featuredImage parameter', async ({ page }) => {
+    await page.goto(`${BASE_URL}/blog/test-image-featured-image/`);
+
+    const jsonLd = await parseJsonLd(page);
+    const blogPosting = jsonLd.find(item => item['@type'] === 'BlogPosting');
+    expect(blogPosting).toBeTruthy();
+    expect(blogPosting?.headline).toBe('Test Post - FeaturedImage Parameter');
+    
+    // Verify image is correctly extracted from featuredImage parameter
+    expect(blogPosting?.image).toBeTruthy();
+    expect(Array.isArray(blogPosting?.image)).toBe(true);
+    const imageArray = blogPosting?.image as string[];
+    expect(imageArray.length).toBeGreaterThan(0);
+    expect(imageArray[0]).toContain('/img/blog/test-featured-image.png');
+  });
+
+  test('blog post JSON-LD falls back to site-level image when no page image specified', async ({ page }) => {
+    await page.goto(`${BASE_URL}/blog/test-image-no-image/`);
+
+    const jsonLd = await parseJsonLd(page);
+    const blogPosting = jsonLd.find(item => item['@type'] === 'BlogPosting');
+    expect(blogPosting).toBeTruthy();
+    expect(blogPosting?.headline).toBe('Test Post - No Image Fallback');
+    
+    // Verify image falls back to site-level image from hugo.toml (params.images)
+    expect(blogPosting?.image).toBeTruthy();
+    expect(Array.isArray(blogPosting?.image)).toBe(true);
+    const imageArray = blogPosting?.image as string[];
+    expect(imageArray.length).toBeGreaterThan(0);
+    expect(imageArray[0]).toContain('/img/og-img.png');
+  });
+
+  test('blog post JSON-LD extracts image from images array format', async ({ page }) => {
+    await page.goto(`${BASE_URL}/blog/test-image-array-format/`);
+
+    const jsonLd = await parseJsonLd(page);
+    const blogPosting = jsonLd.find(item => item['@type'] === 'BlogPosting');
+    expect(blogPosting).toBeTruthy();
+    expect(blogPosting?.headline).toBe('Test Post - Images Array Format');
+    
+    // Verify image is correctly extracted from images array (first element)
+    expect(blogPosting?.image).toBeTruthy();
+    expect(Array.isArray(blogPosting?.image)).toBe(true);
+    const imageArray = blogPosting?.image as string[];
+    expect(imageArray.length).toBeGreaterThan(0);
+    expect(imageArray[0]).toContain('/img/blog/test-images-array.png');
+  });
 });


### PR DESCRIPTION
Refactor logic for determining page image in jsonld schema to add support for 'featuredImage' front matter parameter. Fallback to 'featured_image' if 'featuredImage' is absent, and then check 'images' for a non-empty slice. Ensures more accurate representation of content's featured image.

Fixes #433 