### PR TITLE
Improve theme metadata for discoverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # Adritian Free Hugo Theme
 A modern, fast and extensible Hugo theme for personal websites and professional landing pages - with blog and portfolio support
 
-[![Vercel Deploy](https://deploy-badge.vercel.app/vercel/adritian-demo?name=demo)
-](https://adritian-demo.vercel.app/) [![Test example site](https://github.com/zetxek/adritian-free-hugo-theme/actions/workflows/test-example-site.yml/badge.svg)](https://github.com/zetxek/adritian-free-hugo-theme/actions/workflows/test-example-site.yml)
+[![Hugo](https://img.shields.io/badge/Hugo-%3E%3D0.123-ff4088?logo=hugo)](https://gohugo.io/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/zetxek/adritian-free-hugo-theme/blob/main/LICENSE)
+[![GitHub stars](https://img.shields.io/github/stars/zetxek/adritian-free-hugo-theme?style=social)](https://github.com/zetxek/adritian-free-hugo-theme/stargazers)
+[![GitHub release](https://img.shields.io/github/v/release/zetxek/adritian-free-hugo-theme)](https://github.com/zetxek/adritian-free-hugo-theme/releases)
+[![Vercel Deploy](https://deploy-badge.vercel.app/vercel/adritian-demo?name=demo)](https://adritian-demo.vercel.app/)
+[![Test example site](https://github.com/zetxek/adritian-free-hugo-theme/actions/workflows/test-example-site.yml/badge.svg)](https://github.com/zetxek/adritian-free-hugo-theme/actions/workflows/test-example-site.yml)
 
 ## 🚀 Key Features
 

--- a/assets/scss/adritian.scss
+++ b/assets/scss/adritian.scss
@@ -35,11 +35,6 @@ html body ::selection {
   padding-right: 24px;
 }
 
-.container {
-  padding-left: 24px;
-  padding-right: 24px;
-}
-
 .h1,
 .h2,
 .h3,

--- a/theme.toml
+++ b/theme.toml
@@ -1,10 +1,10 @@
 # theme.toml template for a Hugo theme
 # See https://github.com/gohugoio/hugoThemes#themetoml for an example
 
-name = "Adritian-Free-Hugo-Theme"
+name = "Adritian"
 license = "MIT"
 licenselink = "https://github.com/zetxek/adritian-free-hugo-theme/blob/main/LICENSE"
-description = "Minimalistic and clean theme for Hugo, great for Single Page personal websites or landing pages. With custom types for blog, portfolio, and content shortcodes."
+description = "A fast, accessible Hugo theme for personal websites and portfolios. Features dark/light mode, multilingual (13 languages + RTL), blog with sidebar, search, skills showcase, SEO-optimized JSON-LD, and perfect Lighthouse scores. Built on Bootstrap 5 with zero jQuery."
 homepage = "https://github.com/zetxek/adritian-free-hugo-theme"
 demosite = "https://adritian-demo.vercel.app"
 min_version = "0.123.0"
@@ -12,7 +12,7 @@ min_version = "0.123.0"
 tags = [
     "responsive",
     "clean",
-    "light",
+    "minimal",
     "personal",
     "bootstrap",
     "blog",
@@ -25,9 +25,30 @@ tags = [
     "sass",
     "archive",
     "landing",
+    "search",
+    "seo",
+    "accessible",
+    "rtl",
 ]
 
-features = ["widgets", "blog", "portfolio", "dark-mode"]
+features = [
+    "dark-mode",
+    "blog",
+    "portfolio",
+    "multilingual",
+    "search",
+    "contact form",
+    "SEO / JSON-LD",
+    "skills showcase",
+    "shortcodes",
+    "print-friendly CV",
+    "RTL support",
+    "social sharing",
+    "comments",
+    "related posts",
+    "table of contents",
+    "reading time",
+]
 
 [author]
 name = "Adrián Moreno Peña"


### PR DESCRIPTION
## Summary
- **theme.toml**: Fix duplicate "light" tag, add high-value tags (`minimal`, `search`, `seo`, `accessible`, `rtl`), expand features array from 4 to 16 entries listing all major capabilities, rewrite description with concrete differentiators, simplify display name to "Adritian"
- **README badges**: Add Hugo version, MIT license, GitHub stars, and latest release badges for at-a-glance project health
- **GitHub topics**: Expanded from 6 to 18 topics (added `personal-website`, `portfolio`, `dark-mode`, `bootstrap`, `multilingual`, `responsive`, `blog`, `landing-page`, `seo`, `accessibility`, `i18n`, `rtl`)
- **CSS cleanup**: Remove duplicate `.container` rule in `adritian.scss`

## Why
The Hugo themes directory (themes.gohugo.io) indexes `theme.toml` metadata for search and filtering. The previous config had a duplicate tag, only 4 features listed, and a generic description. These changes improve how the theme appears in directory search results and on GitHub.

## Test plan
- [ ] Verify theme.toml is valid TOML (`hugo mod verify` or similar)
- [ ] Check README renders correctly on GitHub with all badges
- [ ] Verify no visual regression from the duplicate CSS removal (it was identical)

🤖 Generated with [Claude Code](https://claude.com/claude-code)