### PR TITLE
Fix deprecation warning

### DIFF
--- a/.github/workflows/test-example-site.yml
+++ b/.github/workflows/test-example-site.yml
@@ -22,7 +22,7 @@ jobs:
   prepare:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: ${{ vars.HUGO_VERSION || '0.147.2' }}
+      HUGO_VERSION: ${{ vars.HUGO_VERSION || '0.157.0' }}
     steps:
       - name: Install Hugo CLI
         run: |

--- a/layouts/experience/single.html
+++ b/layouts/experience/single.html
@@ -6,7 +6,7 @@
   <div id="main-content" tabindex="-1">
     <div class="row flex-column-reverse flex-md-row rad-fade-down">
       <div class="col-12 col-md-5 mt-5 mt-sm-0">
-        {{ $baseLangSite := .Sites.Default }}
+        {{ $baseLangSite := hugo.Sites.Default }}
         {{ $currentPageID := .Page.File.UniqueID }}
         
         {{ $xp := (where .Site.RegularPages.ByDate.Reverse "Type" "experience") }}

--- a/layouts/partials/client-and-work.html
+++ b/layouts/partials/client-and-work.html
@@ -19,7 +19,7 @@
      --------------------------------------------------------------------------- */}}
 {{- $clients := slice -}}
 {{- if not $isShortcode -}}
-  {{- $baseLangSite := .Sites.Default -}}
+  {{- $baseLangSite := hugo.Sites.Default -}}
   {{- $clients = (where .Site.RegularPages.ByDate.Reverse "Type" "client-work" | lang.Merge (where $baseLangSite.RegularPages.ByDate.Reverse "Type" "client-work") ) -}}
 {{- else -}}
   {{- $clients = (where .Site.RegularPages.ByDate.Reverse "Type" "client-work") -}}

--- a/layouts/partials/experience.html
+++ b/layouts/partials/experience.html
@@ -29,7 +29,7 @@
 
       {{ $xp := where .Site.RegularPages.ByDate "Type" "experience" }}
       {{ if not $isShortcode }}
-        {{ $baseLangSite := .Sites.Default }}
+        {{ $baseLangSite := hugo.Sites.Default }}
         {{ $xp = $xp | lang.Merge (where $baseLangSite.RegularPages.ByDate.Reverse "Type" "experience") }}
       {{ end }}
 

--- a/layouts/partials/testimonial.html
+++ b/layouts/partials/testimonial.html
@@ -16,7 +16,7 @@
      --------------------------------------------------------------------------- */}}
 {{- $testimonials := (where .Site.RegularPages.ByDate "Type" "testimonial") -}}
 {{- if not $isShortcode }}
-  {{- $baseLangSite := .Sites.Default -}}
+  {{- $baseLangSite := hugo.Sites.Default -}}
   {{- $testimonials = $testimonials | lang.Merge (where $baseLangSite.RegularPages.ByDate "Type" "testimonial") -}}
 {{- end -}}
 


### PR DESCRIPTION
When running site with latest released hugo version 0.157.0, a deprecation warning is shown:

```
INFO  deprecated: .Site.Sites and .Page.Sites was deprecated in Hugo v0.156.0 and will be removed in a future release. Use hugo.Sites instead.
```

This PR fixes that issue.