### PR TITLE
Fix deprecation warning emitted from hugo v0.157.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,7 +149,7 @@ This version introduces a brand new way of managing pages, and leveraging the ex
 
 The main changes are:
 
-- deprecation of `homepage.yml`. Stopped using some of its values (such as `.Site.Data.homepage.newsletter.enable`, given that the shortcodes can be rendered in any page, not only the home)
+- deprecation of `homepage.yml`. Stopped using some of its values (such as `hugo.Data.homepage.newsletter.enable`, given that the shortcodes can be rendered in any page, not only the home)
 - introduction of numerous shortcodes, to replicate the same experience (in any page)
 
 Aside from that:

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -137,7 +137,7 @@ This version introduces a brand new way of managing pages, and leveraging the ex
 
 The main changes are:
 
-- deprecation of `homepage.yml`. Stopped using some of its values (such as `.Site.Data.homepage.newsletter.enable`, given that the shortcodes can be rendered in any page, not only the home)
+- deprecation of `homepage.yml`. Stopped using some of its values (such as `hugo.Data.homepage.newsletter.enable`, given that the shortcodes can be rendered in any page, not only the home)
 - introduction of numerous shortcodes, to replicate the same experience (in any page)
 
 Aside from that:

--- a/layouts/partials/about.html
+++ b/layouts/partials/about.html
@@ -24,15 +24,15 @@
 {{- $imgScale := 0.5 -}}
 
 {{- if $isShortcode }}
-  {{- $imgSrc = .Get "imgSrc" | default .Site.Data.homepage.about.image.src -}}
-  {{- $imgWidth = .Get "imgWidth" | default .Site.Data.homepage.about.image.width -}}
-  {{- $imgHeight = .Get "imgHeight" | default .Site.Data.homepage.about.image.height -}}
-  {{- $imgScale = .Get "imgScale" | default .Site.Data.homepage.about.image.scale -}}
+  {{- $imgSrc = .Get "imgSrc" | default hugo.Data.homepage.about.image.src -}}
+  {{- $imgWidth = .Get "imgWidth" | default hugo.Data.homepage.about.image.width -}}
+  {{- $imgHeight = .Get "imgHeight" | default hugo.Data.homepage.about.image.height -}}
+  {{- $imgScale = .Get "imgScale" | default hugo.Data.homepage.about.image.scale -}}
 {{ else }}
-  {{- $imgSrc = .Site.Data.homepage.about.image.src -}}
-  {{- $imgWidth = .Site.Data.homepage.about.image.width -}}
-  {{- $imgHeight = .Site.Data.homepage.about.image.height -}}
-  {{- $imgScale = .Site.Data.homepage.about.image.scale -}}
+  {{- $imgSrc = hugo.Data.homepage.about.image.src -}}
+  {{- $imgWidth = hugo.Data.homepage.about.image.width -}}
+  {{- $imgHeight = hugo.Data.homepage.about.image.height -}}
+  {{- $imgScale = hugo.Data.homepage.about.image.scale -}}
 {{ end }}
 
 {{/* ---------------------------------------------------------------------------
@@ -47,8 +47,8 @@
   {{- $hAlign = .Get "h_align" | default "left" -}}
 {{ else }}
   {{- /* Support both v_align and text_align for backwards compatibility */ -}}
-  {{- $vAlign = .Site.Data.homepage.about.v_align | default .Site.Data.homepage.about.text_align | default "center" -}}
-  {{- $hAlign = .Site.Data.homepage.about.h_align | default "left" -}}
+  {{- $vAlign = hugo.Data.homepage.about.v_align | default hugo.Data.homepage.about.text_align | default "center" -}}
+  {{- $hAlign = hugo.Data.homepage.about.h_align | default "left" -}}
 {{ end }}
 
 {{/* ---------------------------------------------------------------------------
@@ -59,12 +59,12 @@
 {{- $btnText := "" -}}
 
 {{- if $isShortcode }}
-  {{- $btnURL = .Get "button_url" | default .Site.Data.homepage.about.button.URL -}}
-  {{- $btnIcon = .Get "button_icon" | default .Site.Data.homepage.about.button.icon -}}
+  {{- $btnURL = .Get "button_url" | default hugo.Data.homepage.about.button.URL -}}
+  {{- $btnIcon = .Get "button_icon" | default hugo.Data.homepage.about.button.icon -}}
   {{- $btnText = .Get "button_text" | default false -}}
 {{ else }}
-  {{- $btnURL = .Site.Data.homepage.about.button.URL -}}
-  {{- $btnIcon = .Site.Data.homepage.about.button.icon -}}
+  {{- $btnURL = hugo.Data.homepage.about.button.URL -}}
+  {{- $btnIcon = hugo.Data.homepage.about.button.icon -}}
   {{- $btnText = i18n "about_button" -}}
 {{ end }}
 

--- a/layouts/partials/contact.html
+++ b/layouts/partials/contact.html
@@ -31,11 +31,11 @@
 {{ $form_action := "" }}
 {{ $form_method := "" }}
 {{ if $isShortcode }}
-  {{ $form_action = .Get "form_action" | default .Site.Data.homepage.contact.form_action }}
-  {{ $form_method = .Get "form_method" | default .Site.Data.homepage.contact.form_method }}
+  {{ $form_action = .Get "form_action" | default hugo.Data.homepage.contact.form_action }}
+  {{ $form_method = .Get "form_method" | default hugo.Data.homepage.contact.form_method }}
 {{ else }}
-  {{ $form_action = .Site.Data.homepage.contact.form_action }}
-  {{ $form_method = .Site.Data.homepage.contact.form_method }}
+  {{ $form_action = hugo.Data.homepage.contact.form_action }}
+  {{ $form_method = hugo.Data.homepage.contact.form_method }}
 {{ end }}
 
 {{/*----------------------------------------------
@@ -43,9 +43,9 @@
 ------------------------------------------------*/}}
 {{ $name_placeholder := "" }}
 {{ if $isShortcode }}
-  {{ $name_placeholder = .Get "contact_form_name" | default (.Get "name_placeholder") | default .Site.Data.homepage.contact.form_name_placeholder | default (i18n "contact_name_placeholder") }}
+  {{ $name_placeholder = .Get "contact_form_name" | default (.Get "name_placeholder") | default hugo.Data.homepage.contact.form_name_placeholder | default (i18n "contact_name_placeholder") }}
 {{ else }}
-  {{ $name_placeholder = .Site.Data.homepage.contact.form_name_placeholder | default (i18n "contact_name_placeholder") }}
+  {{ $name_placeholder = hugo.Data.homepage.contact.form_name_placeholder | default (i18n "contact_name_placeholder") }}
 {{ end }}
 {{ $name_placeholder_attr := "" }}
 {{ if $name_placeholder }}
@@ -54,9 +54,9 @@
 
 {{ $email_placeholder := "" }}
 {{ if $isShortcode }}
-  {{ $email_placeholder = .Get "contact_form_email" | default (.Get "email_placeholder") | default .Site.Data.homepage.contact.form_email_placeholder | default (i18n "contact_email_placeholder") }}
+  {{ $email_placeholder = .Get "contact_form_email" | default (.Get "email_placeholder") | default hugo.Data.homepage.contact.form_email_placeholder | default (i18n "contact_email_placeholder") }}
 {{ else }}
-  {{ $email_placeholder = .Site.Data.homepage.contact.form_email_placeholder | default (i18n "contact_email_placeholder") }}
+  {{ $email_placeholder = hugo.Data.homepage.contact.form_email_placeholder | default (i18n "contact_email_placeholder") }}
 {{ end }}
 {{ $email_placeholder_attr := "" }}
 {{ if $email_placeholder }}
@@ -65,9 +65,9 @@
 
 {{ $phone_placeholder := "" }}
 {{ if $isShortcode }}
-  {{ $phone_placeholder = .Get "contact_form_phone" | default (.Get "phone_placeholder") | default .Site.Data.homepage.contact.form_phone_placeholder | default (i18n "contact_phone_placeholder") }}
+  {{ $phone_placeholder = .Get "contact_form_phone" | default (.Get "phone_placeholder") | default hugo.Data.homepage.contact.form_phone_placeholder | default (i18n "contact_phone_placeholder") }}
 {{ else }}
-  {{ $phone_placeholder = .Site.Data.homepage.contact.form_phone_placeholder | default (i18n "contact_phone_placeholder") }}
+  {{ $phone_placeholder = hugo.Data.homepage.contact.form_phone_placeholder | default (i18n "contact_phone_placeholder") }}
 {{ end }}
 {{ $phone_placeholder_attr := "" }}
 {{ if $phone_placeholder }}
@@ -76,9 +76,9 @@
 
 {{ $message_placeholder := "" }}
 {{ if $isShortcode }}
-  {{ $message_placeholder = .Get "contact_form_message" | default (.Get "message_placeholder") | default .Site.Data.homepage.contact.form_message_placeholder | default (i18n "contact_message_placeholder") }}
+  {{ $message_placeholder = .Get "contact_form_message" | default (.Get "message_placeholder") | default hugo.Data.homepage.contact.form_message_placeholder | default (i18n "contact_message_placeholder") }}
 {{ else }}
-  {{ $message_placeholder = .Site.Data.homepage.contact.form_message_placeholder | default (i18n "contact_message_placeholder") }}
+  {{ $message_placeholder = hugo.Data.homepage.contact.form_message_placeholder | default (i18n "contact_message_placeholder") }}
 {{ end }}
 {{ $message_placeholder_attr := "" }}
 {{ if $message_placeholder }}
@@ -98,9 +98,9 @@
 ------------------------------------------------*/}}
 {{ $button_text := "" }}
 {{ if $isShortcode }}
-  {{ $button_text = .Get "contact_button" | default (.Get "button_text") | default .Site.Data.homepage.contact.button_text | default (i18n "contact_button_text") }}
+  {{ $button_text = .Get "contact_button" | default (.Get "button_text") | default hugo.Data.homepage.contact.button_text | default (i18n "contact_button_text") }}
 {{ else }}
-  {{ $button_text = .Site.Data.homepage.contact.button_text | default (i18n "contact_button_text") }}
+  {{ $button_text = hugo.Data.homepage.contact.button_text | default (i18n "contact_button_text") }}
 {{ end }}
 
 {{/*----------------------------------------------
@@ -111,15 +111,15 @@
 {{ $email := "" }}
 {{ $location := "" }}
 {{ if $isShortcode }}
-  {{ $phone = .Get "contact_phone_number" | default (.Get "phone") | default .Site.Data.homepage.contact.phone }}
-  {{ $phone_display = .Get "contact_phone_number" | default (.Get "phone_display") | default .Site.Data.homepage.contact.phone_display | default $phone }}
-  {{ $email = .Get "contact_email_email" | default (.Get "email") | default .Site.Data.homepage.contact.email }}
-  {{ $location = .Get "contact_address_address" | default (.Get "location") | default .Site.Data.homepage.contact.location }}
+  {{ $phone = .Get "contact_phone_number" | default (.Get "phone") | default hugo.Data.homepage.contact.phone }}
+  {{ $phone_display = .Get "contact_phone_number" | default (.Get "phone_display") | default hugo.Data.homepage.contact.phone_display | default $phone }}
+  {{ $email = .Get "contact_email_email" | default (.Get "email") | default hugo.Data.homepage.contact.email }}
+  {{ $location = .Get "contact_address_address" | default (.Get "location") | default hugo.Data.homepage.contact.location }}
 {{ else }}
-  {{ $phone = .Site.Data.homepage.contact.phone }}
-  {{ $phone_display = .Site.Data.homepage.contact.phone_display | default $phone }}
-  {{ $email = .Site.Data.homepage.contact.email }}
-  {{ $location = .Site.Data.homepage.contact.location }}
+  {{ $phone = hugo.Data.homepage.contact.phone }}
+  {{ $phone_display = hugo.Data.homepage.contact.phone_display | default $phone }}
+  {{ $email = hugo.Data.homepage.contact.email }}
+  {{ $location = hugo.Data.homepage.contact.location }}
 {{ end }}
 
 {{/*----------------------------------------------
@@ -129,13 +129,13 @@
 {{ $email_heading := "" }}
 {{ $location_heading := "" }}
 {{ if $isShortcode }}
-  {{ $phone_heading = .Get "contact_phone_title" | default (.Get "phone_heading") | default .Site.Data.homepage.contact.phone_heading | default (i18n "contact_phone_heading") }}
-  {{ $email_heading = .Get "contact_email_title" | default (.Get "email_heading") | default .Site.Data.homepage.contact.email_heading | default (i18n "contact_email_heading") }}
-  {{ $location_heading = .Get "contact_address_title" | default (.Get "location_heading") | default .Site.Data.homepage.contact.location_heading | default (i18n "contact_location_heading") }}
+  {{ $phone_heading = .Get "contact_phone_title" | default (.Get "phone_heading") | default hugo.Data.homepage.contact.phone_heading | default (i18n "contact_phone_heading") }}
+  {{ $email_heading = .Get "contact_email_title" | default (.Get "email_heading") | default hugo.Data.homepage.contact.email_heading | default (i18n "contact_email_heading") }}
+  {{ $location_heading = .Get "contact_address_title" | default (.Get "location_heading") | default hugo.Data.homepage.contact.location_heading | default (i18n "contact_location_heading") }}
 {{ else }}
-  {{ $phone_heading = .Site.Data.homepage.contact.phone_heading | default (i18n "contact_phone_heading") }}
-  {{ $email_heading = .Site.Data.homepage.contact.email_heading | default (i18n "contact_email_heading") }}
-  {{ $location_heading = .Site.Data.homepage.contact.location_heading | default (i18n "contact_location_heading") }}
+  {{ $phone_heading = hugo.Data.homepage.contact.phone_heading | default (i18n "contact_phone_heading") }}
+  {{ $email_heading = hugo.Data.homepage.contact.email_heading | default (i18n "contact_email_heading") }}
+  {{ $location_heading = hugo.Data.homepage.contact.location_heading | default (i18n "contact_location_heading") }}
 {{ end }}
 
 <section {{if $sectionId}} id="{{ $sectionId }}"{{end}} class="section section--contact pt-0">

--- a/layouts/partials/experience-description.html
+++ b/layouts/partials/experience-description.html
@@ -34,12 +34,12 @@
 
 {{- if $isShortcode }}
   {{- $btn1Enable = true -}}
-  {{- $btn1Icon = .Get "button1_icon" | default .Site.Data.homepage.experience.button.icon -}}
+  {{- $btn1Icon = .Get "button1_icon" | default hugo.Data.homepage.experience.button.icon -}}
   {{- $btn1URL = .Get "button1_url" | default ( i18n "experience_button_url" ) -}}
   {{- $btn1Text = .Get "button1_text" | default ( i18n "experience_button" ) -}}
 {{ else }}
-  {{- $btn1Enable = .Site.Data.homepage.experience.button.enable -}}
-  {{- $btn1Icon = .Site.Data.homepage.experience.button.icon -}}
+  {{- $btn1Enable = hugo.Data.homepage.experience.button.enable -}}
+  {{- $btn1Icon = hugo.Data.homepage.experience.button.icon -}}
   {{- $btn1URL = i18n "experience_button_url" -}}
   {{- $btn1Text = i18n "experience_button" -}}
 {{ end }}
@@ -59,12 +59,12 @@
   {{- if eq $hideViewAll "true" -}}
     {{- $btn2Enable = false -}}
   {{- end -}}
-  {{- $btn2Icon = .Get "button2_icon" | default .Site.Data.homepage.experience.button2.icon -}}
+  {{- $btn2Icon = .Get "button2_icon" | default hugo.Data.homepage.experience.button2.icon -}}
   {{- $btn2URL = .Get "button2_url" | default ( i18n "experience_button2_url" ) -}}
   {{- $btn2Text = .Get "button2_text" | default ( i18n "experience_button2" ) -}}
 {{ else }}
-  {{- $btn2Enable = .Site.Data.homepage.experience.button2.enable -}}
-  {{- $btn2Icon = .Site.Data.homepage.experience.button2.icon -}}
+  {{- $btn2Enable = hugo.Data.homepage.experience.button2.enable -}}
+  {{- $btn2Icon = hugo.Data.homepage.experience.button2.icon -}}
   {{- $btn2URL = i18n "experience_button2_url" -}}
   {{- $btn2Text = i18n "experience_button2" -}}
 {{ end }}
@@ -84,12 +84,12 @@
   {{- if eq $hideViewAll "true" -}}
     {{- $btn3Enable = false -}}
   {{- end -}}
-  {{- $btn3Icon = .Get "button3_icon" | default .Site.Data.homepage.experience.button3.icon -}}
+  {{- $btn3Icon = .Get "button3_icon" | default hugo.Data.homepage.experience.button3.icon -}}
   {{- $btn3URL = .Get "button3_url" | default ( i18n "experience_button3_url" ) -}}
   {{- $btn3Text = .Get "button3_text" | default ( i18n "experience_button3" ) -}}
 {{ else }}
-  {{- $btn3Enable = .Site.Data.homepage.experience.button3.enable -}}
-  {{- $btn3Icon = .Site.Data.homepage.experience.button3.icon -}}
+  {{- $btn3Enable = hugo.Data.homepage.experience.button3.enable -}}
+  {{- $btn3Icon = hugo.Data.homepage.experience.button3.icon -}}
   {{- $btn3URL = i18n "experience_button3_url" -}}
   {{- $btn3Text = i18n "experience_button3" -}}
 {{ end }}

--- a/layouts/partials/experience.html
+++ b/layouts/partials/experience.html
@@ -80,7 +80,7 @@
         {{ $xpExtra := sub $xpCount $totalCount }}
         <em>And {{ $xpExtra }} more</em><br />
         <a href="{{ absURL "experience" | relLangURL }}" class="btn btn-primary btn-all-experience">
-          <i class="{{ .Site.Data.homepage.experience.button3.icon }}"></i>
+          <i class="{{ hugo.Data.homepage.experience.button3.icon }}"></i>
           {{ i18n "experience_button3" }}
         </a>
       </div>

--- a/layouts/partials/newsletter.html
+++ b/layouts/partials/newsletter.html
@@ -8,11 +8,11 @@
 {{- $formAction := "" -}}
 {{- $formMethod := "" -}}
 {{- if $isShortcode }}
-    {{- $formAction = .Get "form_action" | default .Site.Data.homepage.newsletter.form.action -}}
-    {{- $formMethod = .Get "form_method" | default .Site.Data.homepage.newsletter.form.method -}}
+    {{- $formAction = .Get "form_action" | default hugo.Data.homepage.newsletter.form.action -}}
+    {{- $formMethod = .Get "form_method" | default hugo.Data.homepage.newsletter.form.method -}}
 {{ else }}
-    {{- $formAction = .Site.Data.homepage.newsletter.form.action -}}
-    {{- $formMethod = .Site.Data.homepage.newsletter.form.method -}}
+    {{- $formAction = hugo.Data.homepage.newsletter.form.action -}}
+    {{- $formMethod = hugo.Data.homepage.newsletter.form.method -}}
 {{ end }}
 
 {{/*

--- a/layouts/partials/showcase.html
+++ b/layouts/partials/showcase.html
@@ -35,27 +35,27 @@
       {{- $showcaseTitle = .Get "title" | default ( i18n "showcase_title" ) -}}
       {{- $showcaseSubtitle = .Get "subtitle" | default ( i18n "showcase_subtitle" ) -}}
       {{- $showcaseDescription = .Get "description" | default ( i18n "showcase_description" ) | safeHTML -}}
-      {{- $buttonURL = .Get "button_url" | default .Site.Data.homepage.showcase.button.URL -}}
-      {{- $buttonIcon = .Get "button_icon" | default .Site.Data.homepage.showcase.button.icon -}}
+      {{- $buttonURL = .Get "button_url" | default hugo.Data.homepage.showcase.button.URL -}}
+      {{- $buttonIcon = .Get "button_icon" | default hugo.Data.homepage.showcase.button.icon -}}
       {{- $buttonText = .Get "button_text" | default false -}}
-      {{- $imgSrc = .Get "imgSrc" | default .Site.Data.homepage.showcase.image.src -}}
-      {{- $imgWidth = .Get "imgWidth" | default .Site.Data.homepage.showcase.image.width -}}
-      {{- $imgHeight = .Get "imgHeight" | default .Site.Data.homepage.showcase.image.height -}}
-      {{- $imgScale = .Get "imgScale" | default .Site.Data.homepage.showcase.image.scale -}}
+      {{- $imgSrc = .Get "imgSrc" | default hugo.Data.homepage.showcase.image.src -}}
+      {{- $imgWidth = .Get "imgWidth" | default hugo.Data.homepage.showcase.image.width -}}
+      {{- $imgHeight = .Get "imgHeight" | default hugo.Data.homepage.showcase.image.height -}}
+      {{- $imgScale = .Get "imgScale" | default hugo.Data.homepage.showcase.image.scale -}}
       {{- $socialLinks = .Get "social_links" -}}
     {{ else }}
       {{/* Fallback site or i18n */}}
       {{- $showcaseTitle = i18n "showcase_title" -}}
       {{- $showcaseSubtitle = i18n "showcase_subtitle" -}}
       {{- $showcaseDescription = i18n "showcase_description" | safeHTML -}}
-      {{- $buttonURL = .Site.Data.homepage.showcase.button.URL -}}
-      {{- $buttonIcon = .Site.Data.homepage.showcase.button.icon -}}
+      {{- $buttonURL = hugo.Data.homepage.showcase.button.URL -}}
+      {{- $buttonIcon = hugo.Data.homepage.showcase.button.icon -}}
       {{- $buttonText = i18n "showcase_button" -}}
-      {{- $imgSrc = .Site.Data.homepage.showcase.image.src -}}
-      {{- $imgWidth = .Site.Data.homepage.showcase.image.width -}}
-      {{- $imgHeight = .Site.Data.homepage.showcase.image.height -}}
-      {{- $imgScale = .Site.Data.homepage.showcase.image.scale -}}
-      {{- $socialLinks = .Site.Data.homepage.showcase.socialLinks -}}
+      {{- $imgSrc = hugo.Data.homepage.showcase.image.src -}}
+      {{- $imgWidth = hugo.Data.homepage.showcase.image.width -}}
+      {{- $imgHeight = hugo.Data.homepage.showcase.image.height -}}
+      {{- $imgScale = hugo.Data.homepage.showcase.image.scale -}}
+      {{- $socialLinks = hugo.Data.homepage.showcase.socialLinks -}}
     {{ end }}
 
 


### PR DESCRIPTION
When running site with latest released hugo version 0.157.0, a deprecation warning is shown:

```
INFO  deprecated: .Site.Data was deprecated in Hugo v0.156.0 and will be removed in a future release.
Use hugo.Data instead.
```

This PR fixes that issue.