### PR TITLE
fix: prevent workflow failures for external contributor (fork) PRs

### DIFF
--- a/.github/workflows/update-demo-pr-external.yml
+++ b/.github/workflows/update-demo-pr-external.yml
@@ -30,8 +30,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: theme-source
-          ref: ${{ github.head_ref }}
-          token: ${{ secrets.PRIVATE_TOKEN_GITHUB }}
+          # Use the fork repo and exact commit SHA for external PRs (pull_request_target).
+          # No token needed for public forks.
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
       
       - name: Checkout demo repository
         uses: actions/checkout@v4

--- a/.github/workflows/update-demo-pr.yml
+++ b/.github/workflows/update-demo-pr.yml
@@ -78,7 +78,9 @@ jobs:
 
   update-demo:
     needs: check-dependabot
-    if: needs.check-dependabot.outputs.should-run == 'true'
+    # Skip for fork PRs: PRIVATE_TOKEN_GITHUB is unavailable in pull_request context for forks.
+    # External contributor PRs are handled by update-demo-pr-external.yml instead.
+    if: needs.check-dependabot.outputs.should-run == 'true' && !github.event.pull_request.head.repo.fork
     env:
       SOURCE_BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       PR_NUMBER: ${{ github.event.number }}


### PR DESCRIPTION
## Summary

Fixes two workflow failures that occur when external contributors (from forks) open PRs.

### Issue 1 — `update-demo-pr.yml` crashes for fork PRs

**Trigger:** `pull_request` — GitHub does NOT expose repository secrets (`PRIVATE_TOKEN_GITHUB`) to this workflow when triggered from a fork. The checkout step receives an empty token and fails with:

```
Input required and not supplied: token
```

**Fix:** Add `&& !github.event.pull_request.head.repo.fork` to the `update-demo` job condition. Fork PRs are already handled by `update-demo-pr-external.yml` via `pull_request_target`.

### Issue 2 — `update-demo-pr-external.yml` checks out wrong repo

**Trigger:** `pull_request_target` with `safe to test` label — the checkout step had:
```yaml
ref: ${{ github.head_ref }}          # fork's branch name
token: ${{ secrets.PRIVATE_TOKEN_GITHUB }}
# missing: repository field → defaults to BASE repo (zetxek/adritian-free-hugo-theme)
```

The fork's branch doesn't exist in the base repo, so the fetch fails.

**Fix:** Explicitly specify the fork's repository and use the exact commit SHA:
```yaml
repository: ${{ github.event.pull_request.head.repo.full_name }}
ref: ${{ github.event.pull_request.head.sha }}
# No token needed for public forks
```

## Expected behavior after fix

- Internal PRs: `update-demo-pr.yml` runs normally (unchanged)
- Fork PRs: `update-demo-pr.yml` skips `update-demo` cleanly (no error), `update-demo-pr-external.yml` runs when the `safe to test` label is added and correctly checks out the fork's code

🤖 Generated with [Claude Code](https://claude.com/claude-code)