### PR TITLE
Fix deprecation warning

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -12,12 +12,13 @@
 
     {{/* Get available languages for redirect logic */}}
     {{- $languages := slice }}
-    {{- range .Site.Languages }}
-      {{- if ne .Lang "en" }}
-        {{- $languages = $languages | append .Lang }}
+    {{ with .Rotate "language" }}
+      {{- range . }}
+        {{- if ne .Site.Language "en" }}
+          {{- $languages = $languages | append .Lang }}
+        {{- end }}
       {{- end }}
     {{- end }}
-
     <script>
       (function() {
         // Available non-default languages from Hugo config


### PR DESCRIPTION
When running site with latest released hugo version 0.157.0, a deprecation warning is shown:

```
INFO  deprecated: .Site.Languages was deprecated in Hugo v0.156.0 and will be removed in a future release.
See https://discourse.gohugo.io/t/56732
```

This PR fixes that issue.