### PR TITLE
ci: run tests on push to main so they appear as branch protection checks

### DIFF
--- a/.github/workflows/test-example-site.yml
+++ b/.github/workflows/test-example-site.yml
@@ -143,7 +143,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: recursive
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.head_ref || github.ref_name }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js


### PR DESCRIPTION
## Problem

GitHub only shows a workflow's jobs as selectable options in the "Require status checks to pass" branch protection setting if those jobs have **previously run and reported against the protected branch** (`main`).

`test-example-site.yml` was `pull_request`-only, so `prepare`, `test-no-menus`, and `test-with-menus` never ran on `main` — they were invisible in the "Add checks" dropdown.

## Fix

- Add `push: branches: ["main"]` trigger to `test-example-site.yml`
- Guard the snapshot commit-back step with `if: github.event_name == 'pull_request'` to prevent an infinite push loop (snapshot commits would otherwise retrigger the workflow on every merge)

After this merges and the workflow runs once on `main`, the jobs will appear in the branch protection "Add checks" search.

🤖 Generated with [Claude Code](https://claude.com/claude-code)