### PR TITLE
chore: bump Hugo minimum version to 0.153.0

### DIFF
--- a/theme.toml
+++ b/theme.toml
@@ -7,7 +7,7 @@ licenselink = "https://github.com/zetxek/adritian-free-hugo-theme/blob/main/LICE
 description = "A fast, accessible Hugo theme for personal websites and portfolios. Features dark/light mode, multilingual (13 languages + RTL), blog with sidebar, search, skills showcase, SEO-optimized JSON-LD, and perfect Lighthouse scores. Built on Bootstrap 5 with zero jQuery."
 homepage = "https://github.com/zetxek/adritian-free-hugo-theme"
 demosite = "https://adritian-demo.vercel.app"
-min_version = "0.123.0"
+min_version = "0.153.0"
 
 tags = [
     "responsive",


### PR DESCRIPTION
## Summary

- Bumps the minimum required Hugo version from `0.123.0` to `0.153.0` in `theme.toml`
- Required for usage of the `Rotate` function, which was introduced in Hugo 0.153.0

Introduced in https://github.com/zetxek/adritian-free-hugo-theme/pull/470, it aligns the theme with modern Hugo features (and reduces the noise by deprecation warnings).

Prevents confusions like https://github.com/zetxek/adritian-free-hugo-theme/issues/480 - by keeping the minVersion realistic.

## Test plan

- [x] Verify theme builds correctly with Hugo 0.153.0+
- [x] Confirm `Rotate` function works as expected