### PR TITLE
fix: remove deprecated style=social from GitHub stars badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ A modern, fast and extensible Hugo theme for personal websites and professional 
 
 [![Hugo](https://img.shields.io/badge/Hugo-%3E%3D0.153-ff4088?logo=hugo)](https://gohugo.io/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/zetxek/adritian-free-hugo-theme/blob/main/LICENSE)
-[![GitHub stars](https://img.shields.io/github/stars/zetxek/adritian-free-hugo-theme?style=social)](https://github.com/zetxek/adritian-free-hugo-theme/stargazers)
+[![GitHub stars](https://img.shields.io/github/stars/zetxek/adritian-free-hugo-theme)](https://github.com/zetxek/adritian-free-hugo-theme/stargazers)
 [![GitHub release](https://img.shields.io/github/v/release/zetxek/adritian-free-hugo-theme)](https://github.com/zetxek/adritian-free-hugo-theme/releases)
 [![Vercel Deploy](https://deploy-badge.vercel.app/vercel/adritian-demo?name=demo)](https://adritian-demo.vercel.app/)
 [![Test example site](https://github.com/zetxek/adritian-free-hugo-theme/actions/workflows/test-example-site.yml/badge.svg)](https://github.com/zetxek/adritian-free-hugo-theme/actions/workflows/test-example-site.yml)


### PR DESCRIPTION
## Summary

- Removes `?style=social` from the GitHub stars badge URL

shields.io dropped support for the `social` style on dynamic badges, causing the Stars badge to render as "invalid" in the README.

## Test plan

- [x] Stars badge renders correctly with a count (not "invalid")

🤖 Generated with [Claude Code](https://claude.com/claude-code)