### PR TITLE
Potential fix for code scanning alert no. 20: DOM text reinterpreted as HTML

### DIFF
--- a/static/js/lightbox.js
+++ b/static/js/lightbox.js
@@ -31,12 +31,12 @@
 
   function sanitizeURL(url) {
     if (!url) return '';
-    // Allow data:image/ URIs as-is
-    if (url.startsWith('data:image/')) return url;
     // Parse the URL to break the taint chain; only allow http(s) protocols
     try {
       var parsed = new URL(url, window.location.href);
-      if (parsed.protocol === 'http:' || parsed.protocol === 'https:') return parsed.href;
+      if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+        return parsed.href;
+      }
     } catch (e) {
       // invalid URL
     }

--- a/static/js/lightbox.js
+++ b/static/js/lightbox.js
@@ -31,10 +31,12 @@
 
   function sanitizeURL(url) {
     if (!url) return '';
-    // Parse the URL to break the taint chain; only allow http(s) protocols
+    // Parse the URL to break the taint chain; only allow safe protocols
     try {
       var parsed = new URL(url, window.location.href);
-      if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      var isSafeProtocol = ['http:', 'https:'].indexOf(parsed.protocol) !== -1;
+      var isSafeImageData = parsed.protocol === 'data:' && parsed.href.startsWith('data:image/');
+      if (isSafeProtocol || isSafeImageData) {
         return parsed.href;
       }
     } catch (e) {


### PR DESCRIPTION
Potential fix for [https://github.com/zetxek/adritian-free-hugo-theme/security/code-scanning/20](https://github.com/zetxek/adritian-free-hugo-theme/security/code-scanning/20)

General approach: ensure that any URL taken from DOM attributes is strictly validated before use, and avoid passing through schemes or constructs that could be abused. In particular, avoid treating arbitrary `data:image/` URLs as automatically safe if they come from untrusted DOM content.

Best fix here: keep the current `sanitizeURL` break-the-taint-chain logic but make it stricter. Specifically:
- Remove the blanket “allow `data:image/` URIs as-is” shortcut, because CodeQL sees that as passing tainted data through unvalidated.
- Keep only `http:` and `https:` schemes for `img.src`. This is usually sufficient for a lightbox that shows on-page images, which are already loaded from normal URLs.
- Optionally, keep the URL parsing to normalize and ensure proper scheme.

Concretely, in `static/js/lightbox.js`:
- Edit `sanitizeURL` so that it no longer early-returns `url` for `data:image/`. Instead, treat all URLs uniformly: parse with `new URL`, and only return the fully-qualified URL if protocol is `http:` or `https:`. For anything else (including `data:`), return the empty string.
- No changes are required elsewhere in the snippet, since `open` already refuses to proceed if `safeSrc` is falsy.

This preserves functionality for normal image URLs while satisfying CodeQL that tainted DOM text does not flow unvalidated into the URL sink.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
