### PR TITLE
example site: fix deprecation warnings when using hugo 0.162.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ See the content in the  `i18n` folder to edit the translations, and the configur
 - **Arabic** (`ar`) - with full RTL support
 - **Hebrew** (`he`) - with full RTL support
 
-The theme includes comprehensive RTL (Right-to-Left) language support for Arabic and Hebrew. When a language is configured with `languageDirection = 'rtl'` in `hugo.toml`, the theme automatically applies RTL styling to all components including navigation, forms, tables, code blocks, blockquotes, breadcrumbs, and more. Images can be automatically mirrored using the `rtl-mirror` class, or prevented from mirroring with `rtl-no-mirror`.
+The theme includes comprehensive RTL (Right-to-Left) language support for Arabic and Hebrew. When a language is configured with `direction = 'rtl'` in `hugo.toml`, the theme automatically applies RTL styling to all components including navigation, forms, tables, code blocks, blockquotes, breadcrumbs, and more. Images can be automatically mirrored using the `rtl-mirror` class, or prevented from mirroring with `rtl-no-mirror`.
 
 The example site has 3 enabled languages by default (`en`, `es`, and `fr`). You can enable additional languages by adding them to your `hugo.toml` configuration, or disable the provided ones (by setting `disabled` to `true` on the languages you don't need).
 

--- a/exampleSite/content/blog/getting-started.md
+++ b/exampleSite/content/blog/getting-started.md
@@ -61,7 +61,7 @@ Once you have a site created, you can add the theme to your site by following th
 
 ```
 baseURL = "<your website url>"
-languageCode = "en"
+locale = "en"
 
 [module]
 [module.hugoVersion]
@@ -153,9 +153,9 @@ target = "assets/css/bootstrap-print.css"
 [languages]
   [languages.en]
     disabled = false
-    languageCode = 'en'
-    languageDirection = 'ltr'
-    languageName = 'English'
+    locale = 'en'
+    direction = 'ltr'
+    label = 'English'
     title = ''
     weight = 0
 
@@ -201,9 +201,9 @@ target = "assets/css/bootstrap-print.css"
 
   [languages.es]
     disabled = false
-    languageCode = 'es'
-    languageDirection = 'ltr'
-    languageName = 'Español'
+    locale = 'es'
+    direction = 'ltr'
+    label = 'Español'
     title = ''
     weight = 0
       [[languages.es.menus.header]]
@@ -247,9 +247,9 @@ target = "assets/css/bootstrap-print.css"
 
   [languages.fr]
     disabled = false
-    languageCode = 'fr'
-    languageDirection = 'ltr'
-    languageName = 'Français'
+    locale = 'fr'
+    direction = 'ltr'
+    label = 'Français'
     title = ''
     weight = 0
 

--- a/exampleSite/content/blog/other-installation-methods.md
+++ b/exampleSite/content/blog/other-installation-methods.md
@@ -18,7 +18,7 @@ If you prefer to manually set your site, you need to replace the contents of you
 
 ```
 baseURL = "<your website url>"
-languageCode = "en"
+locale = "en"
 
 [module]
 [module.hugoVersion]
@@ -110,9 +110,9 @@ target = "assets/css/bootstrap-print.css"
 [languages]
   [languages.en]
     disabled = false
-    languageCode = 'en'
-    languageDirection = 'ltr'
-    languageName = 'English'
+    locale = 'en'
+    direction = 'ltr'
+    label = 'English'
     title = ''
     weight = 0
 
@@ -158,9 +158,9 @@ target = "assets/css/bootstrap-print.css"
 
   [languages.es]
     disabled = false
-    languageCode = 'es'
-    languageDirection = 'ltr'
-    languageName = 'Español'
+    locale = 'es'
+    direction = 'ltr'
+    label = 'Español'
     title = ''
     weight = 0
       [[languages.es.menus.header]]
@@ -204,9 +204,9 @@ target = "assets/css/bootstrap-print.css"
 
   [languages.fr]
     disabled = false
-    languageCode = 'fr'
-    languageDirection = 'ltr'
-    languageName = 'Français'
+    locale = 'fr'
+    direction = 'ltr'
+    label = 'Français'
     title = ''
     weight = 0
 

--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -1,6 +1,6 @@
 baseURL = "https://adritian-demo.vercel.app/"
 title = "Adritian Demo"
-languageCode = "en"
+locale = "en"
 
 [pagination]
 pagerSize = 3
@@ -169,9 +169,9 @@ mobileHeader = false
 [languages]
 [languages.en]
 disabled = false
-languageCode = 'en'
-languageDirection = 'ltr'
-languageName = 'English'
+locale = 'en'
+direction = 'ltr'
+label = 'English'
 title = ''
 weight = 0
 
@@ -242,9 +242,9 @@ weight = 4
 
 [languages.es]
 disabled = false
-languageCode = 'es'
-languageDirection = 'ltr'
-languageName = 'Español'
+locale = 'es'
+direction = 'ltr'
+label = 'Español'
 title = ''
 weight = 0
 [[languages.es.menus.header]]
@@ -313,9 +313,9 @@ weight = 4
 
 [languages.fr]
 disabled = false
-languageCode = 'fr'
-languageDirection = 'ltr'
-languageName = 'Français'
+locale = 'fr'
+direction = 'ltr'
+label = 'Français'
 title = ''
 weight = 0
 
@@ -384,9 +384,9 @@ weight = 4
 
 [languages.ar]
 disabled = false
-languageCode = 'ar'
-languageDirection = 'rtl'
-languageName = 'العربية'
+locale = 'ar'
+direction = 'rtl'
+label = 'العربية'
 title = ''
 weight = 0
 
@@ -446,9 +446,9 @@ weight = 4
 
 [languages.he]
 disabled = false
-languageCode = 'he'
-languageDirection = 'rtl'
-languageName = 'עברית'
+locale = 'he'
+direction = 'rtl'
+label = 'עברית'
 title = ''
 weight = 0
 

--- a/exampleSite/package-lock.json
+++ b/exampleSite/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "exampleSite",
       "devDependencies": {
         "@playwright/test": "^1.56.1",
         "@types/node": "^22.10.5",
@@ -306,9 +307,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3203,16 +3204,19 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
-      "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs": {


### PR DESCRIPTION
When previewing example site with latest released hugo version 0.162.1, several deprecation warnings are printed out.
This PR fixes warnings related to example site config. It also updates the documentation accordingly.