### PR TITLE
feat(i18n): add Korean (ko) translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ See the content in the  `i18n` folder to edit the translations, and the configur
 - **Swedish** (`sv`)
 - **Norwegian** (`no`)
 - **Polish** (`pl`)
+- **Korean** (`ko`)
 - **Arabic** (`ar`) - with full RTL support
 - **Hebrew** (`he`) - with full RTL support
 

--- a/i18n/ko.yaml
+++ b/i18n/ko.yaml
@@ -1,0 +1,309 @@
+## Meta tags
+- id: "meta_title"
+  translation: "Adritian - Adrián Moreno가 만든 고성능 Hugo 테마"
+- id: "meta_description"
+  translation: "이 Hugo 테마(Adritian)는 Bootstrap을 기반으로 하며, 개인 사이트나 포트폴리오, 그 밖의 싱글 페이지 애플리케이션에 적합한 기능을 갖추고 있습니다."
+- id: "meta_keywords"
+  translation: "hugo, 테마, bootstrap, adritian, adrian moreno, 개인 사이트, 포트폴리오, 싱글 페이지 애플리케이션"
+- id: "meta_author"
+  translation: "Adrián Moreno Peña"
+- id: "meta_image"
+  translation: "/img/general/og-image.jpg"
+
+## Header
+
+- id: "logo_alt"
+  translation: "Adritian 로고"
+
+- id: "logo_text1"
+  translation: "Adritian"
+
+- id: "logo_text2"
+  translation: "데모"
+
+## General
+- id: "skipToMainContent"
+  translation: "본문으로 건너뛰기"
+
+- id: "toggle_navigation"
+  translation: "내비게이션 토글"
+
+## Footer
+- id: "footer_notice"
+  translation: "© Adritian. Adrián Moreno Peña가 만든 무료 Hugo 테마."
+
+- id: "language"
+  translation: "언어"
+
+- id: "toggle_theme"
+  translation: "테마 전환"
+
+- id: "theme_light"
+  translation: "☀️ 라이트"
+- id: "theme_dark"
+  translation: "🌑 다크"
+- id: "theme_auto"
+  translation: "✨ 자동"
+
+## Color Scheme
+- id: "color_scheme"
+  translation: "색상 구성"
+
+## Search
+- id: "search_tags_label"
+  translation: "태그"
+- id: "search_categories_label"
+  translation: "카테고리"
+- id: "search_filter_by_tag"
+  translation: "태그로 검색 결과 필터링"
+- id: "search_filter_by_category"
+  translation: "카테고리로 검색 결과 필터링"
+- id: "search_title"
+  translation: "사이트 검색"
+- id: "search_placeholder"
+  translation: "검색어를 입력하세요..."
+- id: "search_results_heading"
+  translation: "일치하는 페이지"
+- id: "search_min_chars"
+  translation: "검색하려면 최소 2자 이상 입력하세요"
+- id: "search_no_matches"
+  translation: "일치하는 결과가 없습니다"
+- id: "search_loading"
+  translation: "불러오는 중..."
+- id: "search_error_generic"
+  translation: "검색 중 문제가 발생했습니다. 잠시 후 다시 시도해 주세요."
+- id: "search_untitled"
+  translation: "제목 없음"
+- id: "search_no_preview"
+  translation: "미리보기를 사용할 수 없습니다"
+
+
+## Homepage head title
+- id: "head_title"
+  translation: "Adritian 데모 사이트 - Adrián Moreno가 만든 고성능 Hugo 테마"
+
+- id: "head_description"
+  translation: "이 Hugo 테마(Adritian)는 Bootstrap을 기반으로 하며, 개인 사이트나 포트폴리오, 그 밖의 싱글 페이지 애플리케이션에 적합한 기능을 갖추고 있습니다."
+
+## Homepage showcase
+- id: "showcase_title"
+  translation: "데모에 오신 것을 환영합니다"
+
+- id: "showcase_subtitle"
+  translation: "예시를 함께 살펴봅시다"
+
+- id: "showcase_description"
+  translation: "Hugo 정적 사이트 생성기를 위한 고성능 테마입니다. 이 예시 콘텐츠는 로케일 파일에서 수정할 수 있습니다(테마가 다국어 번역을 지원하기 때문입니다)."
+
+- id: "showcase_button"
+  translation: "문의하기"
+
+  ## not visible but used for accessibility
+- id: "showcase_image_alt"
+  translation: "Cool Name 님의 사진"
+
+## Homepage about
+- id: "about_title"
+  translation: "저는 누구일까요?"
+
+- id: "about_content"
+  translation: '<p class="lead">여기에 자신에 대한 정보를 추가할 수 있습니다. 예를 들어 경력을 설명하는 짧은 소개글을 넣어보세요. 학업이나 전공 배경, 선호하는 작업 분야 등을 적을 수 있습니다.</p>'
+
+- id: "about_button"
+  translation: "소개"
+
+## Homepage education
+- id: "education_title"
+  translation: "학력"
+
+## Homepage experience
+- id: "experience_button"
+  translation: "LinkedIn"
+
+- id: "experience_button_url"
+  translation: "https://www.linkedin.com/in/adrianmoreno/"
+
+- id: "experience_button2"
+  translation: "이력서 다운로드"
+
+- id: "experience_button2_url"
+  translation: "/img/general/user-smile-fill.svg"
+
+- id: "experience_button3"
+  translation: "전체 보기"
+
+- id: "experience_button3_url"
+  translation: "/experience"
+
+## Homepage client & work
+- id: "client_work_title"
+  translation: "고객 & 작업"
+
+## Homepage newsletter
+- id: "newsletter_title"
+  translation: "뉴스레터"
+
+- id: "newsletter_button"
+  translation: "구독"
+
+- id: "newsletter_placeholder"
+  translation: "이메일 주소"
+
+- id: "newsletter_success_message"
+  translation: "뉴스레터를 구독해 주셔서 감사합니다!"
+
+- id: "newsletter_error_message"
+  translation: "오류가 발생했습니다. 다시 시도해 주세요."
+
+- id: "newsletter_note"
+  translation: "회원님의 이메일을 다른 곳과 공유하지 않습니다."
+
+## Homepage testimonials
+- id: "testimonials_title"
+  translation: "추천사"
+
+## Homepage contact
+- id: "contact_title"
+  translation: "문의"
+
+- id: "contact_button"
+  translation: "메시지 보내기"
+
+- id: "contact_form_name"
+  translation: "이름"
+
+- id: "contact_form_email"
+  translation: "이메일 주소"
+
+- id: "contact_form_message"
+  translation: "여기에 메시지를 입력하세요"
+
+- id: "contact_phone_title"
+  translation: "전화번호"
+
+- id: "contact_phone_number"
+  translation: "i18n/ko.yaml에 정의됨 (contact_phone_number)"
+
+- id: "contact_email_title"
+  translation: "이메일"
+
+- id: "contact_email_email"
+  translation: 'i18n/ko.yaml에 정의됨 (contact_email_email)'
+
+- id: "contact_address_title"
+  translation: "주소"
+
+- id: "contact_address_address"
+  translation: "i18n/ko.yaml에 정의됨 (contact_address_address)"
+
+## Blog
+- id: "read_more"
+  translation: "더 읽기"
+
+- id: "published_on"
+  translation: "게시일 "
+
+- id: "continue_reading"
+  translation: "계속 읽기"
+
+## Blog Stats (for list-cards layout)
+- id: "blog_stats_posts"
+  translation: "게시글"
+
+- id: "blog_stats_last_updated"
+  translation: "마지막 업데이트"
+
+- id: "blog_stats_first_post"
+  translation: "첫 게시글"
+
+- id: "blog_stats_topics"
+  translation: "주제"
+
+- id: "blog_stats_latest_post"
+  translation: "최신 게시글"
+
+## 404 Page
+- id: "404_title"
+  translation: "페이지를 찾을 수 없습니다"
+- id: "404_description"
+  translation: "죄송합니다. 찾으시는 페이지를 찾을 수 없습니다."
+- id: "404_button"
+  translation: "홈으로 돌아가기"
+
+## Related Posts
+- id: "related_posts"
+  translation: "관련 게시글"
+
+## Social Sharing
+- id: "share_this_post"
+  translation: "이 게시글 공유하기"
+- id: "share_on_twitter"
+  translation: "Twitter에 공유"
+- id: "share_on_linkedin"
+  translation: "LinkedIn에 공유"
+- id: "share_on_facebook"
+  translation: "Facebook에 공유"
+- id: "share_via_email"
+  translation: "이메일로 공유"
+- id: "share_twitter_label"
+  translation: "Twitter"
+- id: "share_linkedin_label"
+  translation: "LinkedIn"
+- id: "share_facebook_label"
+  translation: "Facebook"
+- id: "share_email_label"
+  translation: "이메일"
+- id: "share_on_bluesky"
+  translation: "Bluesky에 공유"
+- id: "share_bluesky_label"
+  translation: "Bluesky"
+- id: "share_on_mastodon"
+  translation: "Mastodon에 공유"
+- id: "share_mastodon_label"
+  translation: "Mastodon"
+
+## Table of Contents
+- id: "table_of_contents"
+  translation: "목차"
+
+## Comments
+- id: "comments"
+  translation: "댓글"
+
+## Reading time and metadata
+- id: "min_read"
+  translation: "분 읽기"
+- id: "last_updated"
+  translation: "업데이트됨"
+
+## Taxonomy
+- id: "categories"
+  translation: "카테고리"
+- id: "post_singular"
+  translation: "게시글"
+- id: "post_plural"
+  translation: "게시글"
+- id: "tags"
+  translation: "태그"
+- id: "authors"
+  translation: "작성자"
+- id: "series"
+  translation: "시리즈"
+- id: "author_posts"
+  translation: "이 작성자의 게시글"
+- id: "series_posts"
+  translation: "시리즈 게시글"
+- id: "series_part"
+  translation: "파트"
+- id: "recent_posts"
+  translation: "최근 게시글"
+- id: "popular_tags"
+  translation: "인기 태그"
+- id: "view_all_tags"
+  translation: "모든 태그 보기"
+
+- id: "primary_navigation"
+  translation: "주요 내비게이션"
+
+- id: "footer_navigation"
+  translation: "푸터 내비게이션"


### PR DESCRIPTION
## Summary

Adds a complete Korean (`ko`) translation for the theme.

- **New file `i18n/ko.yaml`** — translates all existing keys (parity with `en.yaml`), following the conventions used by the other language files:
  - URL/config values (`experience_button_url`, `experience_button2_url`, `meta_image`, …) and brand names (Adritian, LinkedIn, etc.) are kept as-is.
  - The long demo paragraph (`showcase_description`) is condensed, matching the approach in `de.yaml`.
  - Placeholder strings reference `i18n/ko.yaml` instead of `i18n/en.yaml`.
- **README** — lists Korean in the supported-languages section.

The example site config (`hugo.toml`) is intentionally left unchanged, matching how the other non-demo languages (de, nl, da, it, pt, sv, no, pl) ship — the translation file is included without enabling it in the example site.

## Test plan

- [x] `ko.yaml` parses as valid YAML
- [x] Key parity verified against `en.yaml` (no missing or extra keys, no duplicates, no empty translations)