### PR TITLE
fix: enforce minimum Hugo version 0.156.0 in hugo.toml

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -2,7 +2,7 @@
 
   [module.hugoVersion]
     extended = true
-    min = "0.92.0"
+    min = "0.156.0"
 
 # Related content configuration
 [related]


### PR DESCRIPTION
## Summary
- Update `hugo.toml` `[module.hugoVersion].min` from `0.92.0` to `0.156.0`
- `theme.toml` already declares `min_version = "0.158.0"` but `hugo.toml` is what Hugo Modules actually checks — this was never updated after PR #465

## Context
Fixes #546 — users on Hugo <0.156.0 get a cryptic `can't evaluate field Data in type interface {}`` error because `hugo.Data` doesn't exist in those versions.

Closes #546