### PR TITLE
feat(showcase): add johannes-engelke.de to community showcase

### DIFF
--- a/exampleSite/data/showcase.yml
+++ b/exampleSite/data/showcase.yml
@@ -124,3 +124,8 @@ sites:
     github: "FlashX64"
     repo: "FlashX64/vencelides.cz"
     tags: [portfolio, dark-mode]
+
+  - name: "Johannes Engelke"
+    url: "https://johannes-engelke.de"
+    description: "Customer Experience Consultant with 20 years in IT, DevOps, and Cloud Transformation. Specialized in SAP Sales & Service Cloud V2."
+    tags: [portfolio, multilingual]


### PR DESCRIPTION
## What

Adds [johannes-engelke.de](https://johannes-engelke.de) to the community showcase gallery.

## About the site

Johannes Engelke's personal site — a Customer Experience Consultant with 20 years in IT, DevOps, and Cloud Transformation, specialized in SAP Sales & Service Cloud V2. The site is built with the Adritian Hugo theme and is bilingual (English/German).

## Changes

- Added a new entry to `exampleSite/data/showcase.yml` following the existing format (name, url, description, tags)
- No GitHub source repo is linked as none is publicly available; the `repo` field is optional in the showcase template

## Checklist

- [x] Entry follows the existing YAML format
- [x] Site verified to be built with the Adritian theme (footer credits the theme)
- [x] Tags match existing conventions (`portfolio`, `multilingual`)