### PR TITLE
fix: set enableRobotsTXT so layouts/robots.txt actually renders

### DIFF
--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -2,6 +2,11 @@ baseURL = "https://adritian-demo.vercel.app/"
 title = "Adritian Demo"
 locale = "en"
 
+# Required for the theme's layouts/robots.txt to be rendered — Hugo ignores
+# a custom robots.txt template unless this is explicitly enabled.
+# https://gohugo.io/templates/robots/
+enableRobotsTXT = true
+
 [pagination]
 pagerSize = 3
 

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,3 +1,8 @@
+# Required for layouts/robots.txt to be rendered — Hugo ignores a custom
+# robots.txt template unless this is explicitly enabled.
+# https://gohugo.io/templates/robots/
+enableRobotsTXT = true
+
 [module]
 
   [module.hugoVersion]

--- a/tests/e2e/robots.spec.ts
+++ b/tests/e2e/robots.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from '@playwright/test';
+
+const BASE_URL: string = process.env.TEST_BASE_URL ?? 'http://localhost:1313';
+
+if (!BASE_URL.startsWith('http')) {
+  throw new Error('TEST_BASE_URL must be a valid URL starting with http:// or https://');
+}
+
+// Regression coverage for enableRobotsTXT being unset (issue #562): Hugo
+// silently skips a custom robots.txt template unless enableRobotsTXT=true
+// is set in site config, so layouts/robots.txt previously never rendered.
+test.describe('robots.txt', () => {
+  test('is accessible and returns a 200', async ({ page }) => {
+    const response = await page.goto(`${BASE_URL}/robots.txt`);
+    expect(response?.status()).toBe(200);
+  });
+
+  test('is served as plain text', async ({ page }) => {
+    const response = await page.goto(`${BASE_URL}/robots.txt`);
+    const contentType = response?.headers()['content-type'] ?? '';
+    expect(contentType).toMatch(/text\/plain/i);
+  });
+
+  test('declares a User-agent directive', async ({ page }) => {
+    await page.goto(`${BASE_URL}/robots.txt`);
+    const body = await page.locator('body').innerText();
+    expect(body).toContain('User-agent: *');
+  });
+
+  test('references the sitemap at the site root', async ({ page }) => {
+    await page.goto(`${BASE_URL}/robots.txt`);
+    const body = await page.locator('body').innerText();
+    expect(body).toContain(`Sitemap: ${BASE_URL}/sitemap.xml`);
+  });
+
+  test('disallows crawling outside of production (hugo.IsProduction / site.Params.env unset in test env)', async ({ page }) => {
+    await page.goto(`${BASE_URL}/robots.txt`);
+    const body = await page.locator('body').innerText();
+    expect(body).toContain('Disallow: /');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #562 — `layouts/robots.txt` defines a custom robots.txt template, but Hugo silently ignores custom robots.txt templates unless `enableRobotsTXT = true` is set in site config. That flag was never set, so every site built with this theme shipped with **no robots.txt at all**.

## Changes

- `hugo.toml`: add `enableRobotsTXT = true` (root theme config)
- `exampleSite/hugo.toml`: add the same flag — Hugo Modules don't inherit root-level scalar config from an imported module, so the flag has to be set in the config users actually copy, not just the theme's own root config.

## Verification

Rebuilt `exampleSite` before/after:
- Before: no `robots.txt` in `public/`
- After: `public/robots.txt` generated correctly:
  ```
  User-agent: *
  Disallow:
  Sitemap: https://adritian-demo.vercel.app/sitemap.xml
  ```

## Test plan

- [x] `cd exampleSite && hugo --minify` produces `public/robots.txt`
- [x] Content respects the existing `hugo.IsProduction` / `site.Params.env` logic in the template (unchanged)