### PR TITLE
fix: remove leftover debug warnf logging from home/footer templates

### DIFF
--- a/layouts/_default/home.html
+++ b/layouts/_default/home.html
@@ -17,25 +17,6 @@
     {{- end }}
 </head>
 
-{{/*
-  This template iterates through all pages in the site and logs debugging information.
-  For each page, it prints:
-    - File path (if file exists)
-    - Draft status
-    - Page type
-    - Section
-    - Kind
-  
-  If a page doesn't have an associated file, it logs that information separately.    
-  Warning levels are used to make the output visible in Hugo's build logs.
-*/}}
-{{ range .Site.Pages }}
-  {{ if .File }}
-    {{ warnf "Path: %s | Lang: %s | IsDraft: %t | Type: %s | Section: %s | Kind: %s" .File.Path .Lang .Draft .Type .Section .Kind }}
-  {{ else }}
-    {{ warnf "No .File for this page: Type=%s, Section=%s, Kind=%s" .Type .Section .Kind }}
-  {{ end }}
-{{ end }}
 <body class="{{ if .IsHome }}home{{ end }}">
 
 	{{ partial "header.html" . }}
@@ -44,12 +25,6 @@
     {{ $home := where (where .Site.Pages "Type" "home") "Lang" .Lang }}
     {{ $homeCount := len $home }}
 
-  {{ range $home }}
-  {{ if .File }}
-    {{ warnf "[HOME] Path: %s | Lang: %s | IsDraft: %t | Type: %s | Section: %s | Kind: %s" .File.Path .Lang .Draft .Type .Section .Kind }}
-  {{ end }}
-{{ end }}              
-    
     {{ if lt $homeCount 1 }}
         <!-- DEFAULT -->
         {{ warnf "Adritian: No homepage found for lang '%s' (%d 'home' items). Please create a home in your content folder." .Lang ($homeCount) }}
@@ -60,7 +35,6 @@
         {{ end }}
     {{ else }}
     {{ range (sort $home "Date" "desc") }}
-        {{ warnf "Adritian: Using 'home' content type to render homepage." }}
         <div class="container home-container">
         {{ .Content | safeHTML }}
         </div>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -4,9 +4,6 @@
     {{ $footer := where (where .Site.Pages "Type" "footer") "Lang" .Lang }}
 
     {{ range (sort $footer "Date" "desc") }}
-      {{ if .File }}
-        {{ warnf "[FOOTER] Path: %s | Lang: %s | IsDraft: %t | Type: %s | Section: %s | Kind: %s" .File.Path .Lang .Draft .Type .Section .Kind }}
-      {{ end }}        
       {{ .Content | safeHTML }}
     {{ end }}
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build": "npm run favicons && hugo build --source exampleSite --themesDir ../.. --logLevel debug --minify",
     "build:performance": "npm run optimize:performance && npm run build",
     "optimize:performance": "node scripts/optimize-performance.js",
-    "test:scripts": "node tests/scripts/generate-favicon-ico.test.js",
+    "test:scripts": "node tests/scripts/generate-favicon-ico.test.js && node tests/scripts/no-debug-logging.test.js",
     "test": "npm-run-all build --continue-on-error test:scripts test:e2e test:e2e:no-menus",
     "test:e2e": "export TEST_NO_MENUS=false; playwright test",
     "test:e2e:no-menus": "export TEST_NO_MENUS=true; playwright test",

--- a/tests/scripts/no-debug-logging.test.js
+++ b/tests/scripts/no-debug-logging.test.js
@@ -11,30 +11,45 @@
  * This test runs a real `hugo build` against exampleSite and asserts none
  * of the removed debug-log patterns reappear in the build output.
  *
+ * Playwright auto-discovers every tests/**\/*.test.js file (testDir is
+ * './tests') and runs it in parallel with the browser specs, alongside a
+ * live `hugo server` that's also serving exampleSite/ for those specs. So
+ * this build must NOT touch exampleSite/public or exampleSite/resources —
+ * doing so previously corrupted the live dev server mid-test-run and broke
+ * nearly every e2e spec in CI. Output and the resource cache are redirected
+ * to isolated temp directories instead; exampleSite/ itself is never
+ * written to.
+ *
  * No browser required — suitable for CI/CD pre-e2e checks.
  */
 
 const assert = require('assert');
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 const { spawnSync } = require('child_process');
 
 const themeDir = path.resolve(__dirname, '../..');
 const exampleSiteDir = path.join(themeDir, 'exampleSite');
 
-// Clean cached build artifacts so this is a true from-scratch build.
-for (const dir of ['public', 'resources']) {
-  fs.rmSync(path.join(exampleSiteDir, dir), { recursive: true, force: true });
-}
-for (const file of ['.hugo_build.lock', 'hugo_stats.json']) {
-  fs.rmSync(path.join(exampleSiteDir, file), { force: true });
-}
+const destDir = fs.mkdtempSync(path.join(os.tmpdir(), 'no-debug-logging-dest-'));
+const resourceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'no-debug-logging-resources-'));
 
-const result = spawnSync(
-  'hugo',
-  ['--minify', '--themesDir', '../..'],
-  { encoding: 'utf8', cwd: exampleSiteDir },
-);
+let result;
+try {
+  result = spawnSync(
+    'hugo',
+    ['--minify', '--themesDir', '../..', '--destination', destDir],
+    {
+      encoding: 'utf8',
+      cwd: exampleSiteDir,
+      env: { ...process.env, HUGO_RESOURCEDIR: resourceDir },
+    },
+  );
+} finally {
+  fs.rmSync(destDir, { recursive: true, force: true });
+  fs.rmSync(resourceDir, { recursive: true, force: true });
+}
 
 assert.strictEqual(
   result.status,
@@ -75,13 +90,5 @@ assert.ok(
   `Expected a small number of WARN lines, found ${warnCount}. ` +
     `This may indicate a new per-page debug logging regression.`,
 );
-
-// Clean up build artifacts produced by this test run.
-for (const dir of ['public', 'resources']) {
-  fs.rmSync(path.join(exampleSiteDir, dir), { recursive: true, force: true });
-}
-for (const file of ['.hugo_build.lock', 'hugo_stats.json']) {
-  fs.rmSync(path.join(exampleSiteDir, file), { force: true });
-}
 
 console.log(`✅ no-debug-logging test passed (${warnCount} legitimate WARN line(s), 0 debug-dump lines)`);

--- a/tests/scripts/no-debug-logging.test.js
+++ b/tests/scripts/no-debug-logging.test.js
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Regression test for issue #564: layouts/_default/home.html and
+ * layouts/partials/footer.html used to loop over every page (in every
+ * language) and emit a `warnf` for each one, on every render. This flooded
+ * `hugo build` output with hundreds of debug lines and buried genuinely
+ * actionable warnings.
+ *
+ * This test runs a real `hugo build` against exampleSite and asserts none
+ * of the removed debug-log patterns reappear in the build output.
+ *
+ * No browser required — suitable for CI/CD pre-e2e checks.
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const themeDir = path.resolve(__dirname, '../..');
+const exampleSiteDir = path.join(themeDir, 'exampleSite');
+
+// Clean cached build artifacts so this is a true from-scratch build.
+for (const dir of ['public', 'resources']) {
+  fs.rmSync(path.join(exampleSiteDir, dir), { recursive: true, force: true });
+}
+for (const file of ['.hugo_build.lock', 'hugo_stats.json']) {
+  fs.rmSync(path.join(exampleSiteDir, file), { force: true });
+}
+
+const result = spawnSync(
+  'hugo',
+  ['--minify', '--themesDir', '../..'],
+  { encoding: 'utf8', cwd: exampleSiteDir },
+);
+
+assert.strictEqual(
+  result.status,
+  0,
+  `hugo build failed (exit ${result.status}).\nstdout: ${result.stdout}\nstderr: ${result.stderr}`,
+);
+
+const output = `${result.stdout}\n${result.stderr}`;
+
+// Debug patterns that layouts/_default/home.html and
+// layouts/partials/footer.html used to print for every single page.
+const debugPatterns = [
+  { name: 'per-page "Path: ... | Kind: ..." debug dump', re: /WARN\s+Path:.*\|\s*Kind:\s*\S+/ },
+  { name: '"[HOME] Path: ..." debug dump', re: /WARN\s+\[HOME]\s+Path:/ },
+  { name: '"[FOOTER] Path: ..." debug dump', re: /WARN\s+\[FOOTER]\s+Path:/ },
+  { name: '"No .File for this page" debug dump', re: /WARN\s+No \.File for this page:/ },
+];
+
+const failures = [];
+for (const { name, re } of debugPatterns) {
+  const matches = output.match(new RegExp(re, 'g')) || [];
+  if (matches.length > 0) {
+    failures.push(`${name}: found ${matches.length} occurrence(s)`);
+  }
+}
+
+assert.strictEqual(
+  failures.length,
+  0,
+  `Debug logging regression detected in hugo build output:\n${failures.join('\n')}`,
+);
+
+// Sanity ceiling: a healthy build should have a small, bounded number of
+// WARN lines (deprecation notices, config issues) — not hundreds.
+const warnCount = (output.match(/WARN\s/g) || []).length;
+assert.ok(
+  warnCount < 20,
+  `Expected a small number of WARN lines, found ${warnCount}. ` +
+    `This may indicate a new per-page debug logging regression.`,
+);
+
+// Clean up build artifacts produced by this test run.
+for (const dir of ['public', 'resources']) {
+  fs.rmSync(path.join(exampleSiteDir, dir), { recursive: true, force: true });
+}
+for (const file of ['.hugo_build.lock', 'hugo_stats.json']) {
+  fs.rmSync(path.join(exampleSiteDir, file), { force: true });
+}
+
+console.log(`✅ no-debug-logging test passed (${warnCount} legitimate WARN line(s), 0 debug-dump lines)`);


### PR DESCRIPTION
## Summary

Fixes #564 — `layouts/_default/home.html` looped over `.Site.Pages` (every page, every language) and called `warnf` for each one on every homepage render. `layouts/partials/footer.html` did the same for the footer content match, and since the footer partial is included on every page, it fired once per page build too. Both were explicitly leftover debug code (the removed comment block literally said "this template iterates through all pages... and logs debugging information").

## Changes

- `layouts/_default/home.html`: removed the full-`.Site.Pages` debug loop and the separate `[HOME]`-prefixed debug loop. Kept the functional warnings (no homepage found, deprecated `Site.Params.Sections` usage).
- `layouts/partials/footer.html`: removed the `[FOOTER]`-prefixed per-render debug warnf.

## Why this matters beyond noise

- It buried genuinely actionable warnings (e.g. the missing-title/description warnf from #561) under hundreds of irrelevant lines.
- It did a full `.Site.Pages` scan on every homepage render (once per language) purely for logging — wasted build-time work.

## What about the debugging value it provided?

Considered keeping it behind an opt-in `params.debug.pageInfo` flag rather than removing it outright, since knowing each page's path/lang/draft/type/section/kind is genuinely useful when diagnosing content-classification issues (e.g. "why isn't this rendering as home"). But Hugo already ships this as a builtin CLI command — **`hugo list all`** — with zero template code required:

```
$ hugo list all --themesDir ../..
path,slug,title,date,expiryDate,publishDate,draft,permalink,kind,section
content/footer/footer.es.md,,Footer,...,false,https://.../es/footer/footer/,page,footer
content/home/home.fr.md,,Accueil,...,false,https://.../fr/home/home/,page,home
```

That covers path, draft status, kind, and section as CSV, on-demand, per-language (visible in the `permalink` column). The only field it doesn't carry is the front-matter `type`, which for this theme's content layout coincides with `section` anyway. Given that, a custom verbose flag would mostly be reimplementing an existing Hugo CLI feature inside the theme's templates — not worth the added param surface and per-build overhead. `hugo list all` is the better tool for this going forward.

## Verification

Rebuilt `exampleSite`:
- Before: hundreds of `WARN Path: ... | Kind: page` / `[HOME]` / `[FOOTER]` lines per build
- After: 6 WARN lines total, all pre-existing/legitimate (Hugo deprecation notices + the `Unknown kind "footer" in outputs configuration` warning, unrelated to this change — tracked separately)
- Homepage content (`home-container`) and footer content (`footer__copy`) both still render correctly in `public/index.html`

## Test plan

- [x] `cd exampleSite && hugo --minify` succeeds
- [x] Build log no longer flooded with per-page debug warnings
- [x] Homepage and footer content unchanged in output
- [x] `hugo list all` confirmed as the equivalent replacement for ad-hoc page-classification debugging