### PR TITLE
fix: restore default archetype scaffolding

### DIFF
--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -1,2 +1,5 @@
 +++
+title = "{{ replace .Name "-" " " | title }}"
+date = {{ .Date }}
+draft = true
 +++

--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -1,5 +1,5 @@
 +++
-title = "{{ replace .Name "-" " " | title }}"
+title = "{{ .Name | replaceRE `[_-]` ` ` | title }}"
 date = {{ .Date }}
 draft = true
 +++

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build": "npm run favicons && hugo build --source exampleSite --themesDir ../.. --logLevel debug --minify",
     "build:performance": "npm run optimize:performance && npm run build",
     "optimize:performance": "node scripts/optimize-performance.js",
-    "test:scripts": "node tests/scripts/generate-favicon-ico.test.js",
+    "test:scripts": "node tests/scripts/generate-favicon-ico.test.js && node tests/scripts/default-archetype.test.js",
     "test": "npm-run-all build --continue-on-error test:scripts test:e2e test:e2e:no-menus",
     "test:e2e": "export TEST_NO_MENUS=false; playwright test",
     "test:e2e:no-menus": "export TEST_NO_MENUS=true; playwright test",

--- a/tests/scripts/default-archetype.test.js
+++ b/tests/scripts/default-archetype.test.js
@@ -77,7 +77,27 @@ try {
     `Generated archetype is missing "draft = true".\nContent:\n${content}`,
   );
 
-  console.log('✅ default-archetype test passed (title/date/draft present in hugo new output)');
+  // Title formatting must replace both hyphens and underscores with spaces
+  // (per code review feedback on #567 — the initial version only handled
+  // hyphens, so "my_post" rendered as "My_post" instead of "My Post").
+  const mixedRelPath = 'content/my_hyphen-and_underscore-test.md';
+  const mixedResult = spawnSync(
+    'hugo',
+    ['new', mixedRelPath, '--themesDir', path.join(themeDir, '..')],
+    { encoding: 'utf8', cwd: tmpSite },
+  );
+  assert.strictEqual(
+    mixedResult.status,
+    0,
+    `hugo new (mixed separators) failed (exit ${mixedResult.status}).\nstdout: ${mixedResult.stdout}\nstderr: ${mixedResult.stderr}`,
+  );
+  const mixedContent = fs.readFileSync(path.join(tmpSite, mixedRelPath), 'utf8');
+  assert.ok(
+    /^title\s*=\s*"My Hyphen and Underscore Test"$/m.test(mixedContent),
+    `Expected title to replace both hyphens and underscores with spaces.\nContent:\n${mixedContent}`,
+  );
+
+  console.log('✅ default-archetype test passed (title/date/draft present, hyphens and underscores both formatted correctly)');
 } finally {
   fs.rmSync(tmpSite, { recursive: true, force: true });
 }

--- a/tests/scripts/default-archetype.test.js
+++ b/tests/scripts/default-archetype.test.js
@@ -7,29 +7,50 @@
  * (title/date/draft) for any content type without its own dedicated
  * archetype. `hugo new` produced files with no front matter at all.
  *
- * This test runs `hugo new` against exampleSite for a content type that has
- * no dedicated archetype (there's no archetypes/page.md, etc.) and asserts
+ * This test builds a standalone site that imports only the theme (via the
+ * classic --themesDir mechanism) and runs `hugo new` against it, asserting
  * the generated front matter includes title, date, and draft = true.
+ *
+ * Playwright auto-discovers every tests/**\/*.test.js file (testDir is
+ * './tests') and runs it in parallel with the browser specs, alongside a
+ * live `hugo server` that's also serving exampleSite/ for those specs. This
+ * test previously created (then deleted) a content file directly inside
+ * exampleSite/content/, which the live dev server's file-watcher picks up
+ * and rebuilds on — that create+delete churn, racing against the other
+ * ~290 concurrently-running specs, was a plausible source of the
+ * intermittent Spanish-search-index timeouts seen in CI (search.spec.ts).
+ * Using a fully isolated standalone site avoids touching exampleSite/ at
+ * all, matching the safe pattern used by generate-favicon-ico.test.js and
+ * the i18n-format/param-casing-fallback scripts.
  *
  * No browser required — suitable for CI/CD pre-e2e checks.
  */
 
 const assert = require('assert');
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 const { spawnSync } = require('child_process');
 
 const themeDir = path.resolve(__dirname, '../..');
-const exampleSiteDir = path.join(themeDir, 'exampleSite');
+const themeName = path.basename(themeDir);
 
-const relPath = `content/_archetype-regression-test-${Date.now()}.md`;
-const absPath = path.join(exampleSiteDir, relPath);
+const tmpSite = fs.mkdtempSync(path.join(os.tmpdir(), 'default-archetype-test-'));
 
 try {
+  fs.mkdirSync(path.join(tmpSite, 'content'), { recursive: true });
+
+  fs.writeFileSync(
+    path.join(tmpSite, 'hugo.toml'),
+    `baseURL = 'http://localhost/'\nlanguageCode = 'en-us'\ntitle = 'Default Archetype Test'\ntheme = '${themeName}'\n`,
+  );
+
+  const relPath = 'content/regression-test.md';
+
   const result = spawnSync(
     'hugo',
-    ['new', relPath, '--themesDir', '../..'],
-    { encoding: 'utf8', cwd: exampleSiteDir },
+    ['new', relPath, '--themesDir', path.join(themeDir, '..')],
+    { encoding: 'utf8', cwd: tmpSite },
   );
 
   assert.strictEqual(
@@ -38,6 +59,7 @@ try {
     `hugo new failed (exit ${result.status}).\nstdout: ${result.stdout}\nstderr: ${result.stderr}`,
   );
 
+  const absPath = path.join(tmpSite, relPath);
   assert.ok(fs.existsSync(absPath), `Expected generated file not found: ${absPath}`);
 
   const content = fs.readFileSync(absPath, 'utf8');
@@ -57,5 +79,5 @@ try {
 
   console.log('✅ default-archetype test passed (title/date/draft present in hugo new output)');
 } finally {
-  fs.rmSync(absPath, { force: true });
+  fs.rmSync(tmpSite, { recursive: true, force: true });
 }

--- a/tests/scripts/default-archetype.test.js
+++ b/tests/scripts/default-archetype.test.js
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Regression test for issue #566: archetypes/default.md shipped empty
+ * (`+++`/`+++`), which discards Hugo's built-in default archetype
+ * (title/date/draft) for any content type without its own dedicated
+ * archetype. `hugo new` produced files with no front matter at all.
+ *
+ * This test runs `hugo new` against exampleSite for a content type that has
+ * no dedicated archetype (there's no archetypes/page.md, etc.) and asserts
+ * the generated front matter includes title, date, and draft = true.
+ *
+ * No browser required — suitable for CI/CD pre-e2e checks.
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const themeDir = path.resolve(__dirname, '../..');
+const exampleSiteDir = path.join(themeDir, 'exampleSite');
+
+const relPath = `content/_archetype-regression-test-${Date.now()}.md`;
+const absPath = path.join(exampleSiteDir, relPath);
+
+try {
+  const result = spawnSync(
+    'hugo',
+    ['new', relPath, '--themesDir', '../..'],
+    { encoding: 'utf8', cwd: exampleSiteDir },
+  );
+
+  assert.strictEqual(
+    result.status,
+    0,
+    `hugo new failed (exit ${result.status}).\nstdout: ${result.stdout}\nstderr: ${result.stderr}`,
+  );
+
+  assert.ok(fs.existsSync(absPath), `Expected generated file not found: ${absPath}`);
+
+  const content = fs.readFileSync(absPath, 'utf8');
+
+  assert.ok(
+    /^title\s*=/m.test(content),
+    `Generated archetype is missing a "title" field.\nContent:\n${content}`,
+  );
+  assert.ok(
+    /^date\s*=/m.test(content),
+    `Generated archetype is missing a "date" field.\nContent:\n${content}`,
+  );
+  assert.ok(
+    /^draft\s*=\s*true/m.test(content),
+    `Generated archetype is missing "draft = true".\nContent:\n${content}`,
+  );
+
+  console.log('✅ default-archetype test passed (title/date/draft present in hugo new output)');
+} finally {
+  fs.rmSync(absPath, { force: true });
+}


### PR DESCRIPTION
## Summary

Fixes #566 — `archetypes/default.md` shipped as an empty file (just `+++`/`+++`), which overrides Hugo's built-in default archetype. Hugo normally auto-populates `title`, `date`, and `draft: true` for any `hugo new` call that doesn't match a more specific archetype — but a theme/site-provided `archetypes/default.md` replaces that entirely, and an empty one means the generated file gets no front matter at all.

## Changes

- `archetypes/default.md`: populated with the standard title/date/draft scaffold, matching the style already used by the theme's other archetype files (`archetypes/blog.md`, etc).

## Verification

\`\`\`
$ cd exampleSite && hugo new content/_scratch-test-page.md
Content ".../_scratch-test-page.md" created

$ cat content/_scratch-test-page.md
+++
title = "_Scratch Test Page"
date = 2026-07-15T15:00:15+02:00
draft = true
+++
\`\`\`

Before this change, the same command produced a file with no front matter at all.

## Test plan

- [x] `hugo new content/<file>.md` produces title/date/draft front matter
- [x] Existing dedicated archetypes (blog, authors, etc.) unaffected