### PR TITLE
fix: remove inert config for suppressing footer section output

### DIFF
--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -6,14 +6,12 @@ locale = "en"
 pagerSize = 3
 
 
-# Exclude footer section from generating list pages (index.html and index.xml)
 [outputs]
   page = ["HTML"]
   home = ["HTML", "RSS", "JSON"]
   section = ["HTML", "RSS"]
   taxonomy = ["HTML", "RSS"]
   term = ["HTML", "RSS"]
-  footer = []
 
 [taxonomies]
   tag = "tags"
@@ -21,13 +19,6 @@ pagerSize = 3
   author = "authors"
   series = "series"
   topic = "topics"
-
-# Explicitly prevent the footer section from generating any output
-[outputFormats.footerSection]
-  # Empty configuration to prevent any output
-
-# Specifically disable generation of these kinds for the footer content
-disableKinds = ["footerSection"]
 
 [module]
 [[module.imports]]

--- a/hugo.toml
+++ b/hugo.toml
@@ -51,24 +51,12 @@
       precision = 0
 
 
-# Exclude content with type "footer" from being rendered as HTML pages
-[outputFormats]
-  [outputFormats.footer]
-    mediaType = "text/html"
-    isHTML = true
-    isPlainText = false
-    noUgly = true
-    permalinkable = false
-    path = "footer"
-
-# Disable HTML generation for content with type "footer"
 [outputs]
   page = ["HTML"]
   home = ["HTML", "RSS", "JSON"]
   section = ["HTML", "RSS"]
   taxonomy = ["HTML", "RSS"]
   term = ["HTML", "RSS"]
-  footer = []
 
 # Taxonomies
 [taxonomies]
@@ -78,13 +66,7 @@
   series = "series"
   topic = "topics"
 
-# Disable specific content kinds to prevent footer from being rendered
-disableKinds = ["footer"]
-
-# Configure content by path to prevent footer directory from generating HTML
 [params]
-  [params.disabledContent]
-    paths = ["footer"]
 
   [[module.mounts]]
     source = "archetypes"

--- a/layouts/footer/list.html
+++ b/layouts/footer/list.html
@@ -1,5 +1,7 @@
-{{/*  
+{{/*
   This is an empty template for footer section list pages.
   It intentionally does not generate any HTML output when accessed directly.
   This prevents the generation of both index.html and index.xml for the footer section.
+  This empty template (together with single.html and rss.xml in this directory) is the only
+  thing suppressing output for the "footer" section — no hugo.toml config is needed or used.
 */}}

--- a/layouts/footer/rss.xml
+++ b/layouts/footer/rss.xml
@@ -1,5 +1,7 @@
-{{/*  
+{{/*
   This is an empty template for footer section RSS feeds.
   It intentionally does not generate any XML output.
   This prevents the generation of index.xml for the footer section.
+  This empty template (together with single.html and list.html in this directory) is the only
+  thing suppressing output for the "footer" section — no hugo.toml config is needed or used.
 */}}

--- a/layouts/footer/single.html
+++ b/layouts/footer/single.html
@@ -1,5 +1,7 @@
-{{/*  
+{{/*
   This is an empty template for footer type content.
   It intentionally does not generate any HTML output when accessed directly.
   The footer content is only meant to be included in other templates via partial or shortcode calls.
+  This empty template (together with list.html and rss.xml in this directory) is the only
+  thing suppressing output for the "footer" section — no hugo.toml config is needed or used.
 */}}

--- a/tests/e2e/footer-output-suppression.spec.ts
+++ b/tests/e2e/footer-output-suppression.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from '@playwright/test';
+
+const BASE_URL: string = process.env.TEST_BASE_URL ?? 'http://localhost:1313';
+
+if (!BASE_URL.startsWith('http')) {
+  throw new Error('TEST_BASE_URL must be a valid URL starting with http:// or https://');
+}
+
+// Regression coverage for issue #568: the "footer" content section must never
+// be independently browsable, but its content must still be included inline
+// on every page via the footer partial. The only thing that actually enforces
+// this is that layouts/footer/{single,list,rss.xml}.html are deliberately
+// empty templates — hugo.toml previously had dead outputFormats/outputs/
+// disableKinds config that looked load-bearing but did nothing (confirmed via
+// the "Unknown kind \"footer\" in outputs configuration" build warning it
+// produced). These tests guard against either the empty templates being
+// filled in, or the "footer" section becoming independently browsable again.
+test.describe('Footer section output suppression', () => {
+  test('footer section list page is not browsable', async ({ page }) => {
+    const response = await page.goto(`${BASE_URL}/footer/`);
+    expect(response?.status()).toBe(404);
+  });
+
+  test('footer content single page is not browsable', async ({ page }) => {
+    const response = await page.goto(`${BASE_URL}/footer/footer/`);
+    expect(response?.status()).toBe(404);
+  });
+
+  test('footer section has no RSS feed', async ({ page }) => {
+    const response = await page.goto(`${BASE_URL}/footer/index.xml`);
+    expect(response?.status()).toBe(404);
+  });
+
+  test('footer content (from content/footer/footer.md) still renders inline on the homepage', async ({ page }) => {
+    await page.goto(BASE_URL);
+    // The contact section comes from the footer content type's markdown
+    // body (rendered via the contact-section shortcode), not from static
+    // template markup — so this specifically exercises the
+    // `where .Site.Pages "Type" "footer"` lookup in the footer partial.
+    await expect(page.locator('footer .section--contact')).toBeVisible();
+    await expect(page.locator('footer .section--contact')).toContainText('Reach out');
+  });
+
+  test('footer content still renders inline on a blog post', async ({ page }) => {
+    await page.goto(`${BASE_URL}/blog/sample/`);
+    await expect(page.locator('footer .section--contact')).toBeVisible();
+  });
+
+  test('footer content still renders inline for a translated locale', async ({ page }) => {
+    await page.goto(`${BASE_URL}/es/`);
+    // Spanish footer content uses a different shortcode "id" ("contacto"),
+    // so assert on the locale-agnostic class rather than the section id.
+    await expect(page.locator('footer .section--contact')).toBeVisible();
+    await expect(page.locator('footer .section--contact')).toContainText('Contáctame');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #568 — `hugo.toml` and `exampleSite/hugo.toml` each had `outputFormats`/`outputs`/`disableKinds`/`params.disabledContent` blocks whose comments claim to prevent the `footer` content section from generating HTML/RSS pages. None of it actually does anything:

- `outputs.footer = []` treats `"footer"` as a Hugo **Page Kind**, but it's a section name, not a kind (valid kinds: `page`, `home`, `section`, `taxonomy`, `term`, ...). Hugo logs `WARN Unknown kind "footer" in outputs configuration` on every build and ignores the setting.
- `disableKinds = ["footer"]` in `hugo.toml` (and `["footerSection"]` in `exampleSite/hugo.toml`) actually parse as **nested inside the preceding table** (`[taxonomies]` / `[outputFormats.footerSection]`) rather than at the document root, since no new table header separates them — so even setting that aside, they were never applied as root-level `disableKinds` at all.
- `params.disabledContent.paths = ["footer"]` is never read by any template.
- `[outputFormats.footer]` / `[outputFormats.footerSection]` are never referenced by any content's `outputs` front matter — orphaned definitions.

The **only thing that actually suppresses footer output** is that `layouts/footer/single.html`, `layouts/footer/list.html`, and `layouts/footer/rss.xml` are deliberately empty templates.

## Changes

- Removed the dead `outputFormats.footer[Section]` / `outputs.footer` / `disableKinds` / `params.disabledContent` blocks from `hugo.toml` and `exampleSite/hugo.toml`.
- Added a note to the three empty `layouts/footer/*.html` templates clarifying that they are the real (and sufficient) suppression mechanism, so a future cleanup doesn't restore "equivalent" config that never worked, or fill in the templates assuming config elsewhere still guards the output.

## Verification

Rebuilt `exampleSite` before/after:
- Before: `WARN Unknown kind "footer" in outputs configuration` on every build
- After: warning gone
- Both before and after: no `public/footer/` directory produced, footer content still renders inline on every page via the `footer.html` partial

## Test plan

- [x] Both `hugo.toml` and `exampleSite/hugo.toml` still parse as valid TOML
- [x] `cd exampleSite && hugo --minify` succeeds with no "Unknown kind" warning
- [x] No `public/footer/` output
- [x] Footer content still renders correctly on the homepage