### PR TITLE
fix: normalize snake_case params to camelCase (additive)

### DIFF
--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -82,8 +82,9 @@ themeColor = '#478079'
 # Header logo text. Optional — falls back to .Site.Title when unset.
 # Useful when your SEO/page `title` (long, keyword-rich) should differ
 # from the short brand text shown in the header. See PR #561.
-logo_text1 = 'Adritian'
-logo_text2 = 'Theme'
+# (the snake_case logo_text1/logo_text2 names still work as a fallback)
+logoText1 = 'Adritian'
+logoText2 = 'Theme'
 
 # Color scheme: default | ocean | forest | rose | slate | midnight | warm
 colorScheme = 'default'
@@ -570,7 +571,7 @@ showRecentPosts = true
 recentPostCount = 5
 listStyle = "summary"  # options: simple, summary
 listLayout = "default" # options: default, cards
-featured_sort_by_weight = true
+featuredSortByWeight = true  # snake_case featured_sort_by_weight still works as a fallback
 featured_sort_by_date = false
 
 

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -34,7 +34,11 @@
             <div class="featured-post-container">
               {{ $featuredPosts := where $allPosts ".Params.featured" true }}
               {{ if isset .Site.Params "blog" }}
-                {{ if isset .Site.Params.blog "featured_sort_by_weight" }}
+                {{ if isset .Site.Params.blog "featuredSortByWeight" }}
+                  {{ if .Site.Params.blog.featuredSortByWeight }}
+                    {{ $featuredPosts = sort $featuredPosts "Weight" }}
+                  {{ end }}
+                {{ else if isset .Site.Params.blog "featured_sort_by_weight" }}
                   {{ if .Site.Params.blog.featured_sort_by_weight }}
                     {{ $featuredPosts = sort $featuredPosts "Weight" }}
                   {{ end }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -19,7 +19,8 @@
     <nav class="navbar bd-navbar navbar-expand-lg navbar-light p-0" aria-label='{{ i18n "primary_navigation" }}'>
       <div class="container-fluid">
         <a class="navbar-brand mx-auto" href="{{ .Site.BaseURL | relLangURL }}">
-            {{ $logoText1 := .Site.Params.logo_text1 | default .Site.Title }}
+            {{ $logoText1 := .Site.Params.logoText1 | default .Site.Params.logo_text1 | default .Site.Title }}
+            {{ $logoText2 := .Site.Params.logoText2 | default .Site.Params.logo_text2 | default "" }}
             {{ if .Site.Params.logo }}
             <img
             src="{{ .Site.Params.logo | absURL }}"
@@ -28,7 +29,7 @@
             />
             {{ end }}
           <span>{{ $logoText1 }}</span>
-          <span>{{ .Site.Params.logo_text2 | default "" }}</span>
+          <span>{{ $logoText2 }}</span>
         </a>
         <button
           class="navbar-toggler collapsed"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build": "npm run favicons && hugo build --source exampleSite --themesDir ../.. --logLevel debug --minify",
     "build:performance": "npm run optimize:performance && npm run build",
     "optimize:performance": "node scripts/optimize-performance.js",
-    "test:scripts": "node tests/scripts/generate-favicon-ico.test.js",
+    "test:scripts": "node tests/scripts/generate-favicon-ico.test.js && node tests/scripts/param-casing-fallback.test.js",
     "test": "npm-run-all build --continue-on-error test:scripts test:e2e test:e2e:no-menus",
     "test:e2e": "export TEST_NO_MENUS=false; playwright test",
     "test:e2e:no-menus": "export TEST_NO_MENUS=true; playwright test",

--- a/tests/e2e/param-casing.spec.ts
+++ b/tests/e2e/param-casing.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from '@playwright/test';
+
+const BASE_URL: string = process.env.TEST_BASE_URL ?? 'http://localhost:1313';
+
+if (!BASE_URL.startsWith('http')) {
+  throw new Error('TEST_BASE_URL must be a valid URL starting with http:// or https://');
+}
+
+// Regression coverage for issue #570: Site.Params in this theme are
+// overwhelmingly camelCase, but logo_text1, logo_text2, and
+// blog.featured_sort_by_weight broke that convention. Added camelCase
+// aliases (logoText1, logoText2, blog.featuredSortByWeight) as the primary
+// names, falling back to the old snake_case names — exampleSite/hugo.toml
+// was updated to use the new names as the canonical example.
+test.describe('camelCase param names (logoText1/logoText2/featuredSortByWeight)', () => {
+  test('header logo renders from logoText1/logoText2', async ({ page }) => {
+    await page.goto(BASE_URL);
+    const navbarBrand = page.locator('a.navbar-brand');
+    await expect(navbarBrand.locator('span').first()).toHaveText('Adritian');
+    await expect(navbarBrand.locator('span').nth(1)).toHaveText('Theme');
+  });
+
+  test('blog list builds and renders a featured post using featuredSortByWeight', async ({ page }) => {
+    const response = await page.goto(`${BASE_URL}/blog/`);
+    expect(response?.status()).toBe(200);
+    await expect(page.locator('.featured-post-container')).toBeVisible();
+  });
+});

--- a/tests/scripts/param-casing-fallback.test.js
+++ b/tests/scripts/param-casing-fallback.test.js
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Regression test for issue #570: logoText1/logoText2/blog.featuredSortByWeight
+ * were added as camelCase aliases for the pre-existing snake_case params
+ * (logo_text1/logo_text2/blog.featured_sort_by_weight), falling back to the
+ * old names when the new ones aren't set. This is purely additive — no
+ * existing site config using only the old snake_case names should break.
+ *
+ * This test builds a standalone site that sets *only* the legacy
+ * snake_case params (no camelCase names at all) and asserts the theme
+ * still picks them up correctly, exercising the fallback path directly.
+ *
+ * No browser required — suitable for CI/CD pre-e2e checks.
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const themeDir = path.resolve(__dirname, '../..');
+const themeName = path.basename(themeDir);
+
+const tmpSite = fs.mkdtempSync(path.join(os.tmpdir(), 'param-casing-fallback-test-'));
+
+try {
+  fs.mkdirSync(path.join(tmpSite, 'content', 'blog'), { recursive: true });
+
+  fs.writeFileSync(
+    path.join(tmpSite, 'hugo.toml'),
+    [
+      "baseURL = 'http://localhost/'",
+      "languageCode = 'en-us'",
+      "title = 'Param Casing Fallback Test'",
+      `theme = '${themeName}'`,
+      '',
+      '[params]',
+      "logo_text1 = 'LegacyBrand'",
+      "logo_text2 = 'LegacySubtitle'",
+      '',
+      '[params.blog]',
+      'featured_sort_by_weight = true',
+      '',
+    ].join('\n'),
+  );
+
+  // A featured post so the blog list's featured-sort-by-weight branch runs.
+  fs.writeFileSync(
+    path.join(tmpSite, 'content', 'blog', 'post-1.md'),
+    [
+      '+++',
+      "title = 'Post 1'",
+      'featured = true',
+      'weight = 1',
+      '+++',
+      'Body.',
+    ].join('\n'),
+  );
+
+  const result = spawnSync(
+    'hugo',
+    ['--source', tmpSite, '--themesDir', path.join(themeDir, '..'), '--quiet'],
+    { encoding: 'utf8' },
+  );
+
+  assert.strictEqual(
+    result.status,
+    0,
+    `hugo build failed (exit ${result.status}).\nstdout: ${result.stdout}\nstderr: ${result.stderr}`,
+  );
+
+  const homeHtml = fs.readFileSync(path.join(tmpSite, 'public', 'index.html'), 'utf8');
+  assert.ok(
+    homeHtml.includes('LegacyBrand') && homeHtml.includes('LegacySubtitle'),
+    `Expected header logo to fall back to legacy logo_text1/logo_text2 when logoText1/logoText2 are unset.\nOutput:\n${homeHtml}`,
+  );
+
+  const blogHtml = fs.readFileSync(path.join(tmpSite, 'public', 'blog', 'index.html'), 'utf8');
+  assert.ok(
+    blogHtml.includes('featured-post-container'),
+    `Expected the blog list's featured-post section to build using the legacy blog.featured_sort_by_weight fallback.\nOutput:\n${blogHtml}`,
+  );
+
+  console.log('✅ param-casing-fallback test passed (legacy snake_case params still work when camelCase names are unset)');
+} finally {
+  fs.rmSync(tmpSite, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary

Fixes #570 — nearly all `Site.Params` in this theme are camelCase (`showRecentPosts`, `listLayout`, `readingProgress`, `narrowContent`, `homepageExperienceCount`, ...), but `logo_text1`, `logo_text2`, and `blog.featured_sort_by_weight` broke that convention with snake_case. Same category of config-hygiene drift #561 already cleaned up in i18n keys.

## Changes

- `layouts/partials/header.html`: added `logoText1`/`logoText2` as the primary param names, falling back to `logo_text1`/`logo_text2` when unset, falling back to `.Site.Title`/`""`.
- `layouts/blog/list.html`: added `featuredSortByWeight` as the primary param name under `[params.blog]`, checked before the existing `featured_sort_by_weight`.
- `exampleSite/hugo.toml`: updated to use the new camelCase names as the canonical documented example.

This is **purely additive** — no existing site config breaks, since the old snake_case names are still read as a fallback. Nothing is deprecated or removed.

I was careful to preserve the exact original conditional behavior of `featured_sort_by_weight` in `blog/list.html`: when the param is explicitly set to `false`, featured posts are left unsorted (not re-sorted by date) — that pre-existing quirk is unchanged, just now checked under either param name.

## Verification

Rebuilt `exampleSite` with the new camelCase names set:
- Header logo renders `Adritian` / `Theme` correctly (from `logoText1`/`logoText2`)
- `exampleSite/public/blog/index.html` still contains the featured-post section, build succeeds with no errors using `featuredSortByWeight`

## Test plan

- [x] `cd exampleSite && hugo --minify` succeeds
- [x] Header logo text renders correctly from `logoText1`/`logoText2`
- [x] Blog featured-post sort works with `featuredSortByWeight`
- [x] Old snake_case names still work as a fallback (unchanged code path when new names are unset)