### PR TITLE
fix(ci): grant contents:write to update-example-site workflow

### DIFF
--- a/.github/workflows/update-example-site.yml
+++ b/.github/workflows/update-example-site.yml
@@ -1,6 +1,6 @@
 name: Update Example Site
 permissions:
-  contents: read
+  contents: write
   id-token: write
   pages: write
   pull-requests: write


### PR DESCRIPTION
## Problem

The weekly `Update Example Site` workflow has failed **3 consecutive weeks** (2026-07-05, 07-12, 07-19) with:

```
remote: Permission to zetxek/adritian-free-hugo-theme.git denied to github-actions[bot].
fatal: unable to access '...': The requested URL returned error: 403
```

## Root cause

The workflow declares `permissions: contents: read` but the *Push changes* step runs `git push origin update/exampleSite-*`, which requires write access.

## Fix

One line: `contents: read` → `contents: write`. The other permissions (`pages`, `pull-requests`, etc.) are unchanged.

## Verification

After merge, trigger manually: `gh workflow run update-example-site.yml` — the push step should succeed and open the weekly content PR.

🤖 Prepared by @zetxek using an AI coding agent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated workflow permissions to support writing repository contents during execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->