### PR TITLE
docs: note brace-expansion security bump in v1.10.2 notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This documentation tracks changes across versions, including new features, impro
 
 ### Security
 
-- Dependency updates: `dompurify` (3.4.11 → 3.4.13) — fixes DOM clobbering via `ownerDocument` and hooks bypassing the clone guard during `IN_PLACE` sanitization; `shell-quote` (1.8.4 → 1.10.0) in both the theme and `exampleSite` (#583, #584)
+- Dependency updates: `dompurify` (3.4.11 → 3.4.13) — fixes DOM clobbering via `ownerDocument` and hooks bypassing the clone guard during `IN_PLACE` sanitization; `shell-quote` (1.8.4 → 1.10.0) in both the theme and `exampleSite`; `brace-expansion` (1.1.12 → 1.1.18) (#583, #584, #588)
 
 ### Bug fixes
 


### PR DESCRIPTION
#588 (`brace-expansion` 1.1.12 → 1.1.18, `npm_and_yarn` security group) merged after #589 was opened, so it was missing from the v1.10.2 Security section.

One-line changelog fix so the release notes match what actually ships in the `v1.10.2` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the v1.10.2 security changelog to document an additional dependency update related to `brace-expansion`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->