### PR TITLE
docs: focus changelog on features and fixes, not dependency bumps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,10 @@ This documentation tracks changes across versions, including new features, impro
 
 ## v1.10.2
 
-### Security
-
-- Dependency updates: `dompurify` (3.4.11 → 3.4.13) — fixes DOM clobbering via `ownerDocument` and hooks bypassing the clone guard during `IN_PLACE` sanitization; `shell-quote` (1.8.4 → 1.10.0) in both the theme and `exampleSite` (#583, #584)
-
 ### Bug fixes
 
 - Newsletter: render inline markup in note and status messages (#585)
 - CI: grant `contents: write` to the update-example-site workflow (#580)
-
-### Maintenance
-
-- Dependency updates: `autoprefixer` (10.5.2 → 10.5.4), `postcss` (8.5.19 → 8.5.25), `js-yaml` (5.2.1 → 5.2.3), `fuse.js` (7.4.2 → 7.5.0)
 
 ## v1.10.1
 
@@ -38,19 +30,11 @@ This documentation tracks changes across versions, including new features, impro
 
 - Meta description fallback chain now checks page params before i18n (#561)
 
-### Maintenance
-
-- Dependency updates: `postcss` (8.5.15 → 8.5.16), `autoprefixer` (10.5.0 → 10.5.2), `@types/node`, `png-to-ico`, `@playwright/test`
-
 ## v1.9.15
 
 ### Bug fixes
 
 - Set the minimum Hugo version to 0.156.0 in `hugo.toml` (#558)
-
-### Maintenance
-
-- Dependency updates: `js-yaml` (4.2.0 → 5.2.1), `dompurify` (3.4.10 → 3.4.11), `sharp`, `@types/node`, `@playwright/test`
 
 ## v1.9.14
 
@@ -66,7 +50,6 @@ This documentation tracks changes across versions, including new features, impro
 ### Maintenance
 
 - Add Filip Vencelides to the showcase (#522)
-- Dependency updates: `dompurify` (3.4.1 → 3.4.10), `postcss` (8.5.10 → 8.5.15), `fuse.js` (7.3.0 → 7.4.2), `js-yaml` (4.1.1 → 4.2.0), `sharp`, `shell-quote`, `@types/node`, `@playwright/test`
 
 ## v1.9.13
 


### PR DESCRIPTION
Dependency and security bumps are routine maintenance — already tracked by Dependabot and the security tab — rather than release-note material. This drops the per-version dependency lists from the entries added in #589 (v1.9.14 → v1.10.2), so the changelog reads as what actually changed for people using the theme.

Pure deletions, 17 lines. Substantive maintenance work is kept:

- the i18n flat key-value refactor (#573) under v1.10.1
- the showcase addition (#522) under v1.9.14

Real code-level security work stays too — e.g. the v1.9.11 lightbox `sanitizeURL` hardening (#505) is a genuine fix, not a version bump.

### Not touched

Three older `Dependency updates:` lines predating #589 remain, under **v1.9.13**, **v1.9.11** and **v1.9.9**. Those are your original entries for already-published releases, so I left them alone — say the word and I'll strip them for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the release history for versions 1.10.2, 1.9.15, and 1.9.14.
  * Retained relevant bug-fix information while removing selected maintenance, security, and dependency-update entries.
  * No product functionality or public interfaces were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->