### PR TITLE
chore: repo maintenance for v1.10.3

### DIFF
--- a/.github/workflows/test-example-site.yml
+++ b/.github/workflows/test-example-site.yml
@@ -26,7 +26,7 @@ jobs:
   prepare:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: ${{ vars.HUGO_VERSION || '0.157.0' }}
+      HUGO_VERSION: ${{ vars.HUGO_VERSION || '0.158.0' }}
     steps:
       - name: Install Hugo CLI
         run: |
@@ -71,7 +71,7 @@ jobs:
     needs: prepare
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: ${{ vars.HUGO_VERSION || '0.157.0' }}
+      HUGO_VERSION: ${{ vars.HUGO_VERSION || '0.158.0' }}
     steps:
       - name: Install Hugo CLI
         run: |
@@ -132,7 +132,7 @@ jobs:
     needs: prepare
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: ${{ vars.HUGO_VERSION || '0.157.0' }}
+      HUGO_VERSION: ${{ vars.HUGO_VERSION || '0.158.0' }}
     steps:
       - name: Install Hugo CLI
         run: |

--- a/.github/workflows/update-demo-pr.yml
+++ b/.github/workflows/update-demo-pr.yml
@@ -84,7 +84,7 @@ jobs:
     env:
       SOURCE_BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       PR_NUMBER: ${{ github.event.number }}
-      HUGO_VERSION: ${{ vars.HUGO_VERSION || '0.157.0' }}
+      HUGO_VERSION: ${{ vars.HUGO_VERSION || '0.158.0' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source repository

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 This documentation tracks changes across versions, including new features, improvements, and breaking changes.
 
+## v1.10.3
+
+### Bug fixes
+
+- Enforce the real minimum Hugo version (0.158.0) in `hugo.toml`, so builds on 0.156/0.157 fail loudly instead of silently rendering the wrong `dir` for RTL languages and empty language-switcher labels
+- Restore the print stylesheet, which was silently dropped from the CSS bundle because `bootstrap-print-css` was never declared as a dependency
+- Replace Hugo template APIs deprecated in 0.156/0.158 (`LanguageDirection`, `LanguageName`, `LanguageCode`, `site.Data`), removing the deprecation warnings from every build
+
+### Maintenance
+
+- Test suite honours `TEST_BASE_URL` everywhere instead of hardcoding port 1313, so it no longer runs against an unrelated Hugo server that happens to occupy that port
+
 ## v1.10.2
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This documentation tracks changes across versions, including new features, impro
 
 ### Maintenance
 
-- Test suite honours `TEST_BASE_URL` everywhere instead of hardcoding port 1313, so it no longer runs against an unrelated Hugo server that happens to occupy that port
+- Every e2e test file now honours `TEST_BASE_URL` instead of hardcoding port 1313; combined with `PLAYWRIGHT_PORT`, the suite can be pointed at a free port rather than silently reusing an unrelated Hugo server that already occupies 1313
 
 ## v1.10.2
 

--- a/hugo.toml
+++ b/hugo.toml
@@ -7,7 +7,7 @@ enableRobotsTXT = true
 
   [module.hugoVersion]
     extended = true
-    min = "0.156.0"
+    min = "0.158.0"
 
 # Related content configuration
 [related]

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{- $.Lang }}" dir="{{ .Site.Language.LanguageDirection | default "ltr" }}"
+<html lang="{{- $.Lang }}" dir="{{ .Site.Language.Direction | default "ltr" }}"
     {{- if .Site.Params.colorTheme.auto.disable }}
     data-bs-theme="{{ .Site.Params.colorTheme.forced.theme }}"
     theme-forced="true"

--- a/layouts/_default/home.html
+++ b/layouts/_default/home.html
@@ -1,6 +1,6 @@
 <!-- inject:../components/baseHead/baseHeadStart.html -->
 <!DOCTYPE html>
-<html lang="{{- $.Lang }}" dir="{{ .Site.Language.LanguageDirection | default "ltr" }}"
+<html lang="{{- $.Lang }}" dir="{{ .Site.Language.Direction | default "ltr" }}"
 	{{- if .Site.Params.colorTheme.auto.disable }}
 	data-bs-theme="{{ .Site.Params.colorTheme.forced.theme }}"
 	theme-forced="true"

--- a/layouts/_default/showcase.html
+++ b/layouts/_default/showcase.html
@@ -36,7 +36,7 @@ document.addEventListener('DOMContentLoaded', function () {
     </div>
   </div>
 
-  {{ with site.Data.showcase }}
+  {{ with hugo.Data.showcase }}
   {{ $showcase := .sites }}
   {{ $tags := slice }}
   {{ range $showcase }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -4,14 +4,14 @@
 {{- /* Resolve color scheme from config — defaults to "default" (current theme colors).
        params.primaryColor takes precedence over colorScheme if both are set. */}}
 {{- $schemeName := .Site.Params.colorScheme | default "default" -}}
-{{- $scheme := index site.Data.colorSchemes $schemeName -}}
+{{- $scheme := index hugo.Data.colorSchemes $schemeName -}}
 {{- if and .Site.Params.primaryColor .Site.Params.primaryColor.light -}}
   {{- $scheme = dict "light" .Site.Params.primaryColor.light "dark" (.Site.Params.primaryColor.dark | default .Site.Params.primaryColor.light) "name" "Custom" -}}
   {{- $schemeName = "custom" -}}
 {{- else if not $scheme -}}
   {{- warnf "Color scheme '%s' not found in data/colorSchemes.yaml, falling back to default" $schemeName -}}
   {{- $schemeName = "default" -}}
-  {{- $scheme = index site.Data.colorSchemes "default" -}}
+  {{- $scheme = index hugo.Data.colorSchemes "default" -}}
 {{- end -}}
 {{- $themeColor := .Site.Params.themeColor | default (cond (ne $scheme nil) $scheme.light "#478079") -}}
 <meta name="theme-color" content="{{ $themeColor }}" />
@@ -69,7 +69,7 @@
 {{/* hreflang alternate links for multilingual sites */}}
 {{- if and hugo.IsMultilingual .IsTranslated }}
   {{- range .AllTranslations }}
-  <link rel="alternate" hreflang="{{ .Language.LanguageCode | default .Lang }}" href="{{ .Permalink }}" />
+  <link rel="alternate" hreflang="{{ .Language.Locale | default .Lang }}" href="{{ .Permalink }}" />
   {{- end }}
 {{- end }}
 {{/* RSS Feed Discovery Links */}}
@@ -149,7 +149,7 @@
 {{- if .Site.Params.colorSchemeSwitcher.enable }}
   {{- $overrideTpl := resources.Get "scss/scheme-override.scss" }}
   {{- if $overrideTpl }}
-    {{- range $name, $schemeData := site.Data.colorSchemes }}
+    {{- range $name, $schemeData := hugo.Data.colorSchemes }}
       {{- $overrideScss := $overrideTpl | resources.ExecuteAsTemplate (printf "scss/scheme-override-%s.scss" $name) (dict "scheme" $schemeData "name" $name) }}
       {{- if not hugo.IsProduction }}
         {{- $overrideCss := $overrideScss | css.Sass }}

--- a/layouts/partials/selector-language.html
+++ b/layouts/partials/selector-language.html
@@ -16,14 +16,14 @@ so far the placement can either be header or footer */}}
   <ul class='dropdown-menu dropdown-menu-end {{ if  (eq $direction "up") }}dropup{{ end }}'
     id="languages-dropdown-{{ $placement }}" data-bs-popper="static">
     <li class="dropdown-item current selected">
-      <span>✔️ {{ .Site.Language.Label }}</span>
+      <span>✔️ {{ .Site.Language.Label | default .Lang }}</span>
     </li>
     {{ end }}
     {{ end }}
     {{ range $.Translations }}
     <li class="dropdown-item choice">
-      <a class="dropdown-item translation btn-link d-flex align-items-center show" title="{{ .Site.Language.Label }}"
-        href="{{ .Permalink }}">{{ .Site.Language.Label }}</a>
+      <a class="dropdown-item translation btn-link d-flex align-items-center show" title="{{ .Site.Language.Label | default .Lang }}"
+        href="{{ .Permalink }}">{{ .Site.Language.Label | default .Lang }}</a>
     </li>
     {{ end }}
   </ul>

--- a/layouts/partials/selector-language.html
+++ b/layouts/partials/selector-language.html
@@ -16,14 +16,14 @@ so far the placement can either be header or footer */}}
   <ul class='dropdown-menu dropdown-menu-end {{ if  (eq $direction "up") }}dropup{{ end }}'
     id="languages-dropdown-{{ $placement }}" data-bs-popper="static">
     <li class="dropdown-item current selected">
-      <span>✔️ {{ .Site.Language.LanguageName }}</span>
+      <span>✔️ {{ .Site.Language.Label }}</span>
     </li>
     {{ end }}
     {{ end }}
     {{ range $.Translations }}
     <li class="dropdown-item choice">
-      <a class="dropdown-item translation btn-link d-flex align-items-center show" title="{{ .Site.Language.LanguageName }}"
-        href="{{ .Permalink }}">{{ .Site.Language.LanguageName }}</a>
+      <a class="dropdown-item translation btn-link d-flex align-items-center show" title="{{ .Site.Language.Label }}"
+        href="{{ .Permalink }}">{{ .Site.Language.Label }}</a>
     </li>
     {{ end }}
   </ul>

--- a/layouts/partials/selector-scheme.html
+++ b/layouts/partials/selector-scheme.html
@@ -10,7 +10,7 @@
   </button>
   <ul id="scheme-dropdown-{{ $placement }}" class="dropdown-menu dropdown-menu-end {{ if eq $direction "up" }}dropup{{ end }}"
     aria-labelledby="scheme-selector-{{ $placement }}" data-bs-popper="static">
-    {{- range $name, $scheme := site.Data.colorSchemes }}
+    {{- range $name, $scheme := hugo.Data.colorSchemes }}
     {{- if not (findRE "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$" $scheme.light) }}
       {{- errorf "Invalid light color value for scheme '%s' in data/colorSchemes.yaml: %s. Must be a hex code (e.g., #FFFFFF)." $name $scheme.light }}
     {{- end }}

--- a/layouts/partials/seo/jsonld.html
+++ b/layouts/partials/seo/jsonld.html
@@ -80,7 +80,7 @@
 {{- end -}}
 
 {{- $webSite := dict "@context" "https://schema.org" "@type" "WebSite" "name" $siteTitle "url" $siteUrl "description" $siteDescription -}}
-{{- with .Site.LanguageCode -}}
+{{- with .Site.Language.Locale -}}
   {{- $webSite = merge $webSite (dict "inLanguage" .) -}}
 {{- end -}}
 {{- if $siteImage -}}

--- a/layouts/shortcodes/color-scheme-selector.html
+++ b/layouts/shortcodes/color-scheme-selector.html
@@ -16,7 +16,7 @@
       <span class="current-scheme">{{ i18n "color_scheme" }}</span>
     </button>
     <ul class="dropdown-menu" aria-labelledby="scheme-selector-shortcode-{{ $id }}">
-      {{- range $name, $scheme := site.Data.colorSchemes }}
+      {{- range $name, $scheme := hugo.Data.colorSchemes }}
       {{- if not (findRE "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$" $scheme.light) }}
         {{- errorf "Invalid light color value for scheme '%s' in data/colorSchemes.yaml: %s. Must be a hex code (e.g., #FFFFFF)." $name $scheme.light }}
       {{- end }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "dompurify": "^3.4.13",
+        "dompurify": "^3.4.14",
         "fuse.js": "^7.5.0"
       },
       "devDependencies": {
@@ -14,6 +14,7 @@
         "@zetxek/adritian-theme-helper": "^1.0.5",
         "autoprefixer": "^10.5.4",
         "bootstrap": "^5.3.8",
+        "bootstrap-print-css": "^1.0.1",
         "js-yaml": "^5.3.0",
         "npm-run-all": "^4.1.5",
         "png-to-ico": "^3.0.2",
@@ -863,6 +864,13 @@
         "@popperjs/core": "^2.11.8"
       }
     },
+    "node_modules/bootstrap-print-css": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bootstrap-print-css/-/bootstrap-print-css-1.0.1.tgz",
+      "integrity": "sha512-I73Cw87BaxCccTjo3qEbvn7KRb55msMxTuT7mpkAAY4Obq8iG9xCybdxnJqq+RrykLD79O3092AiJwaKiEex7w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.18",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
@@ -1199,9 +1207,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.13",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
-      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.14.tgz",
+      "integrity": "sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -3864,9 +3872,9 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "dev": true,
       "license": "ISC",
       "bin": {

--- a/package.hugo.json
+++ b/package.hugo.json
@@ -1,9 +1,9 @@
 {
   "devDependencies": {
-    "bootstrap": "^5.3.7",
-    "bootstrap-print-css": "^1.0.0",
-    "autoprefixer": "^10.4.17",
-    "postcss": "^8.5.4",
+    "bootstrap": "^5.3.8",
+    "bootstrap-print-css": "^1.0.1",
+    "autoprefixer": "^10.5.4",
+    "postcss": "^8.5.26",
     "postcss-cli": "^11.0.0",
     "@zetxek/adritian-theme-helper": "^1.0.5"
   }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@zetxek/adritian-theme-helper": "^1.0.5",
     "autoprefixer": "^10.5.4",
     "bootstrap": "^5.3.8",
+    "bootstrap-print-css": "^1.0.1",
     "js-yaml": "^5.3.0",
     "npm-run-all": "^4.1.5",
     "png-to-ico": "^3.0.2",
@@ -29,7 +30,7 @@
     "sharp": "^0.35.3"
   },
   "dependencies": {
-    "dompurify": "^3.4.13",
+    "dompurify": "^3.4.14",
     "fuse.js": "^7.5.0"
   }
 }

--- a/tests/README.md
+++ b/tests/README.md
@@ -186,8 +186,22 @@ Tests use the Playwright configuration in `playwright.config.ts` which:
   ```bash
   TEST_NO_MENUS=true npm run test:e2e
   ```
+- **`PLAYWRIGHT_PORT`**: Port the Hugo server is started on (default: `1313`)
 
 All test files validate that `TEST_BASE_URL` starts with `http://` or `https://` for security.
+
+### If port 1313 is already in use
+
+`playwright.config.ts` sets `reuseExistingServer: true`, so if any other Hugo
+server is already listening on the test port, Playwright will reuse it and the
+whole suite silently runs against the wrong site. If you keep an unrelated Hugo
+server running locally, point the suite at a free port instead — set both
+variables, since `PLAYWRIGHT_PORT` moves the server and `TEST_BASE_URL` moves
+the requests:
+
+```bash
+PLAYWRIGHT_PORT=1414 TEST_BASE_URL=http://localhost:1414 npm run test:e2e
+```
 
 ## Writing New Tests
 

--- a/tests/e2e/basic.spec.ts
+++ b/tests/e2e/basic.spec.ts
@@ -107,7 +107,7 @@ test('footer_right should contain dropdown elements for language, theme, and col
 
 
 test('should load all homepage images correctly', async ({ page }) => {
-  await page.goto('http://localhost:1313');
+  await page.goto(BASE_URL);
   
   // Wait for network to be idle (most images loaded)
   await page.waitForLoadState('networkidle');

--- a/tests/e2e/blog-list-pagination.spec.ts
+++ b/tests/e2e/blog-list-pagination.spec.ts
@@ -1,9 +1,9 @@
 import { test, expect, Page } from '@playwright/test';
 
-const BASE_URL: string = process.env.TEST_BASE_URL ?? process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:1313';
+const BASE_URL: string = process.env.TEST_BASE_URL || process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:1313';
 
 if (!BASE_URL.startsWith('http')) {
-  throw new Error('TEST_BASE_URL must be a valid URL starting with http:// or https://');
+  throw new Error('TEST_BASE_URL/PLAYWRIGHT_BASE_URL must be a valid URL starting with http:// or https://');
 }
 
 /**

--- a/tests/e2e/blog-list-pagination.spec.ts
+++ b/tests/e2e/blog-list-pagination.spec.ts
@@ -1,6 +1,10 @@
 import { test, expect, Page } from '@playwright/test';
 
-const BASE_URL = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:1313';
+const BASE_URL: string = process.env.TEST_BASE_URL ?? process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:1313';
+
+if (!BASE_URL.startsWith('http')) {
+  throw new Error('TEST_BASE_URL must be a valid URL starting with http:// or https://');
+}
 
 /**
  * Dynamically detects the last page number by following pagination links.

--- a/tests/e2e/pagination.spec.ts
+++ b/tests/e2e/pagination.spec.ts
@@ -1,9 +1,9 @@
 import { test, expect } from '@playwright/test';
 
-const BASE_URL: string = process.env.TEST_BASE_URL ?? process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:1313';
+const BASE_URL: string = process.env.TEST_BASE_URL || process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:1313';
 
 if (!BASE_URL.startsWith('http')) {
-  throw new Error('TEST_BASE_URL must be a valid URL starting with http:// or https://');
+  throw new Error('TEST_BASE_URL/PLAYWRIGHT_BASE_URL must be a valid URL starting with http:// or https://');
 }
 
 test.describe('Tag page pagination', () => {

--- a/tests/e2e/pagination.spec.ts
+++ b/tests/e2e/pagination.spec.ts
@@ -1,6 +1,10 @@
 import { test, expect } from '@playwright/test';
 
-const BASE_URL = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:1313';
+const BASE_URL: string = process.env.TEST_BASE_URL ?? process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:1313';
+
+if (!BASE_URL.startsWith('http')) {
+  throw new Error('TEST_BASE_URL must be a valid URL starting with http:// or https://');
+}
 
 test.describe('Tag page pagination', () => {
   test.beforeEach(async ({ page }) => {

--- a/tests/utils/rtl-helpers.ts
+++ b/tests/utils/rtl-helpers.ts
@@ -1,9 +1,9 @@
 import { Page, expect } from '@playwright/test';
 
-const BASE_URL: string = process.env.TEST_BASE_URL ?? process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:1313';
+const BASE_URL: string = process.env.TEST_BASE_URL || process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:1313';
 
 if (!BASE_URL.startsWith('http')) {
-  throw new Error('TEST_BASE_URL must be a valid URL starting with http:// or https://');
+  throw new Error('TEST_BASE_URL/PLAYWRIGHT_BASE_URL must be a valid URL starting with http:// or https://');
 }
 
 /**

--- a/tests/utils/rtl-helpers.ts
+++ b/tests/utils/rtl-helpers.ts
@@ -1,6 +1,10 @@
 import { Page, expect } from '@playwright/test';
 
-const BASE_URL = 'http://localhost:1313';
+const BASE_URL: string = process.env.TEST_BASE_URL ?? process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:1313';
+
+if (!BASE_URL.startsWith('http')) {
+  throw new Error('TEST_BASE_URL must be a valid URL starting with http:// or https://');
+}
 
 /**
  * Navigate to RTL version of a page


### PR DESCRIPTION
Repo maintenance pass: reviewed open bugs and pending dependency updates, then prepared the v1.10.3 release notes.

There were no open issues and no open Dependabot PRs, but the review turned up four latent problems.

## Bug fixes

**Hugo minimum version was set below the real floor.** `theme.toml` and the README both require 0.158.0, but the gate Hugo actually enforces — `[module.hugoVersion] min` in `hugo.toml` — still said 0.156.0. `exampleSite/hugo.toml` uses the per-language `direction`/`label`/`locale` keys introduced in 0.158.0, and older Hugo ignores those keys silently rather than erroring. A 0.156/0.157 build therefore succeeded while rendering the wrong `dir` for RTL languages and empty labels in the language switcher — exactly the failure mode #558 was meant to prevent.

**The print stylesheet was silently missing from the CSS bundle.** `hugo.toml` mounts `node_modules/bootstrap-print-css`, and `exampleSite` loads it via `params.plugins.css`, but the package was never declared in the theme's own `package.json`. `head.html` collects plugin CSS with `with resources.Get`, which skips missing files without an error. Verified by build output: the emitted bundle went from 2120 bytes with zero `@media print` rules to 2879 bytes with the print block present.

**Five deprecated Hugo template APIs** (`LanguageDirection`, `LanguageName`, `LanguageCode`, `.Site.LanguageCode`, `site.Data`) were still in use, printing WARN lines on every build and scheduled for removal. The build is now warning-free.

## Maintenance

**The e2e suite ignored `TEST_BASE_URL` in four places.** `tests/README.md` documents that variable and claims every test file validates it, but `rtl-helpers.ts` hardcoded the URL, the two pagination specs read a different variable, and `basic.spec.ts` had an inline literal bypassing its own const. Combined with `reuseExistingServer: true`, any developer with an unrelated Hugo server on port 1313 ran the entire suite against the wrong site. CI never saw this because its runners have nothing on 1313.

Dependency work: `dompurify` 3.4.13 → 3.4.14, `yaml` → 2.9.0 via `postcss-cli` (clears GHSA-48c2-rrv3-qjmp), and `package.hugo.json` realigned with the versions the theme is actually tested against. `npm audit` is clean.

## Verification

Run against a free port so the suite doesn't reuse a stray server:

```
PLAYWRIGHT_PORT=1414 TEST_BASE_URL=http://localhost:1414 npm run test:e2e
```

| | before | after |
|---|---|---|
| e2e (with menus) | 45 failed / 254 passed | **2 failed / 309 passed** |
| e2e (no menus) | — | **0 failed / 250 passed** |
| script tests | — | **5/5 passed** |
| `npm audit` | 1 moderate | **0 vulnerabilities** |
| build warnings | 5 deprecations | **0** |

The 2 remaining failures are pre-existing and unrelated — a platform-dependent visual snapshot (snapshots are committed from Linux CI, these ran on darwin) and a navbar-overflow test that fails in isolation on unmodified `main` too. Both were confirmed by stashing these changes and re-running.

## Not addressed

Open PRs left alone, since none are dependency updates: #593 (newsletter focus ring, behind main), #597/#592 (bot exampleSite content updates), #559/#518/#517/#456 (features; #518, #517 and #456 have conflicts).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Compatibility**
  - Updated the minimum supported Hugo version to 0.158.0.
  - Improved compatibility with current Hugo template APIs, multilingual metadata, language direction, and color-scheme selection.
  - Restored print stylesheet support.

- **Bug Fixes**
  - Improved end-to-end test URL handling and validation, including support for custom ports and test servers.

- **Documentation**
  - Clarified v1.10.3 release notes.
  - Documented configuring test ports and base URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->