### PR TITLE
docs(readme): fix stale Hugo version badge, add last-commit freshness badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # Adritian Free Hugo Theme
 A modern, fast and extensible Hugo theme for personal websites and professional landing pages - with blog and portfolio support
 
-[![Hugo](https://img.shields.io/badge/Hugo-%3E%3D0.153-ff4088?logo=hugo)](https://gohugo.io/)
+[![Hugo](https://img.shields.io/badge/Hugo-%3E%3D0.158.0-ff4088?logo=hugo)](https://gohugo.io/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/zetxek/adritian-free-hugo-theme/blob/main/LICENSE)
 [![GitHub stars](https://img.shields.io/github/stars/zetxek/adritian-free-hugo-theme)](https://github.com/zetxek/adritian-free-hugo-theme/stargazers)
+[![GitHub last commit](https://img.shields.io/github/last-commit/zetxek/adritian-free-hugo-theme)](https://github.com/zetxek/adritian-free-hugo-theme/commits/main)
 [![GitHub release](https://img.shields.io/github/v/release/zetxek/adritian-free-hugo-theme)](https://github.com/zetxek/adritian-free-hugo-theme/releases)
 [![Vercel Deploy](https://deploy-badge.vercel.app/vercel/adritian-demo?name=demo)](https://adritian-demo.vercel.app/)
 [![Test example site](https://github.com/zetxek/adritian-free-hugo-theme/actions/workflows/test-example-site.yml/badge.svg)](https://github.com/zetxek/adritian-free-hugo-theme/actions/workflows/test-example-site.yml)


### PR DESCRIPTION
## What
- **Fix:** Hugo badge said `>=0.153`, but `theme.toml` (`min_version = "0.158.0"`), CI workflows and the README body all require **0.158.0**. Badge now matches.
- **Add:** [shields.io last-commit badge](https://img.shields.io/github/last-commit/zetxek/adritian-free-hugo-theme) right after the stars badge — shows date of last commit on `main` as a freshness signal for people evaluating the theme.

## Notes
- README-only change, no code impact.
- Badge order: Hugo · License · Stars · **Last commit** · Release · Vercel · Tests.

🤖 Prepared by @zetxek via an AI coding agent (Claude Code), verified by the orchestrator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Hugo version requirement badge to `>=0.158.0`.
  * Added a badge displaying the repository’s latest commit information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->