### PR TITLE
perf: selective Bootstrap SCSS imports + gzip Lighthouse server (mobile 79 → target >90)

### DIFF
--- a/.github/workflows/test-module-init.yml
+++ b/.github/workflows/test-module-init.yml
@@ -160,6 +160,15 @@ jobs:
             - name: Create output directory
               run: mkdir -p ${{ github.workspace }}/tmp/artifacts
                 
+            - name: Pre-compress text assets
+              # http-server --gzip serves pre-compressed .gz files (it does NOT
+              # compress on the fly). Without this, Lighthouse reports
+              # "Enable text compression" and penalizes the mobile score, even
+              # though production (Vercel) serves brotli.
+              run: |
+                find ./public -type f \( -name "*.html" -o -name "*.css" -o -name "*.js" -o -name "*.xml" -o -name "*.svg" -o -name "*.json" \) -exec gzip -k9 {} \;
+                echo "Pre-compressed $(find ./public -name '*.gz' | wc -l) files"
+
             - name: Start local server
               run: |
                 npx http-server ./public -p 8080 --gzip &

--- a/.github/workflows/test-module-init.yml
+++ b/.github/workflows/test-module-init.yml
@@ -162,7 +162,7 @@ jobs:
                 
             - name: Start local server
               run: |
-                npx http-server ./public -p 8080 &
+                npx http-server ./public -p 8080 --gzip &
                 SERVER_PID=$!
                 echo "Started http-server with PID: $SERVER_PID"
                 

--- a/.github/workflows/test-module-init.yml
+++ b/.github/workflows/test-module-init.yml
@@ -171,7 +171,7 @@ jobs:
 
             - name: Start local server
               run: |
-                npx http-server ./public -p 8080 --gzip &
+                npx http-server@14.1.1 ./public -p 8080 --gzip &
                 SERVER_PID=$!
                 echo "Started http-server with PID: $SERVER_PID"
                 

--- a/assets/scss/adritian.scss
+++ b/assets/scss/adritian.scss
@@ -52,10 +52,12 @@ $dark-primary: {{ .scheme.dark }};{{ end }}
 @import "bootstrap/helpers/position"; // .fixed-top on the site header
 @import "bootstrap/helpers/stretched-link";
 @import "bootstrap/helpers/visually-hidden";
+@import "bootstrap/helpers/icon-link"; // .icon-link/.icon-link-hover on blog list read-more links
 
 // Utilities API: generates the d-*, m-*, p-*, gap-*, text-*, flex utility
 // classes used liberally throughout layouts/partials/*.html. Must be
-// imported last, mirroring Bootstrap's own bootstrap.scss ordering.
+// imported last among the Bootstrap imports, mirroring Bootstrap's own
+// bootstrap.scss ordering (theme partials below are imported afterwards).
 @import "bootstrap/utilities/api";
 
 @import "navbar";

--- a/assets/scss/adritian.scss
+++ b/assets/scss/adritian.scss
@@ -5,7 +5,59 @@ $dark-primary: {{ .scheme.dark }};{{ end }}
 
 @import "variables";
 @import "theme-init";
-@import "bootstrap/bootstrap";
+
+// Bootstrap: selective imports of only the modules the theme's own
+// layouts/partials use, instead of the full framework (~89% of the full
+// Bootstrap CSS build was unused). Downstream sites' content classes are
+// intentionally NOT considered here — only theme-level markup is. When
+// adding new theme markup that needs a Bootstrap component, add its
+// matching partial import below.
+
+// Configuration (required by every component; mixins/utilities emit no
+// CSS on their own, so importing them in full carries no size cost)
+@import "bootstrap/functions";
+@import "bootstrap/variables";
+@import "bootstrap/variables-dark";
+@import "bootstrap/maps";
+@import "bootstrap/mixins";
+@import "bootstrap/utilities";
+
+// Base layout & typography (blockquote/list/heading styling used by
+// arbitrary rendered blog/markdown content across downstream sites)
+@import "bootstrap/root";
+@import "bootstrap/reboot";
+@import "bootstrap/type";
+@import "bootstrap/images";
+@import "bootstrap/containers";
+@import "bootstrap/grid";
+
+// Forms: search box, contact form, newsletter form
+@import "bootstrap/forms/form-control";
+@import "bootstrap/forms/form-text";
+@import "bootstrap/forms/input-group";
+
+@import "bootstrap/buttons";
+@import "bootstrap/transitions"; // .fade/.collapsing animation used by navbar collapse & dropdowns
+@import "bootstrap/dropdown"; // language/theme/color-scheme selectors
+@import "bootstrap/nav";
+@import "bootstrap/navbar"; // main site nav (collapse + dropdown JS)
+@import "bootstrap/card"; // blog/experience/showcase cards
+@import "bootstrap/breadcrumb"; // blog/page breadcrumbs (used in layouts/)
+@import "bootstrap/progress"; // skills showcase progress bars
+@import "bootstrap/pagination"; // Hugo's _internal/pagination.html output
+@import "bootstrap/alert"; // search "no results", newsletter fail state
+@import "bootstrap/badge"; // taxonomy counts, showcase tags
+
+// Helpers actually referenced in layouts/
+@import "bootstrap/helpers/position"; // .fixed-top on the site header
+@import "bootstrap/helpers/stretched-link";
+@import "bootstrap/helpers/visually-hidden";
+
+// Utilities API: generates the d-*, m-*, p-*, gap-*, text-*, flex utility
+// classes used liberally throughout layouts/partials/*.html. Must be
+// imported last, mirroring Bootstrap's own bootstrap.scss ordering.
+@import "bootstrap/utilities/api";
+
 @import "navbar";
 @import "menu";
 @import "raditian";


### PR DESCRIPTION
## Problem
Mobile Lighthouse performance was **79** (desktop 99) — see the [report on #606](https://github.com/zetxek/adritian-free-hugo-theme/pull/606#issuecomment-5483207832). The theme advertises perfect Lighthouse scores, so mobile lagging matters.

Analysis of the [full CI report](https://github.com/zetxek/adritian-free-hugo-theme/actions/runs/33429035589): FCP 3.3s / LCP 4.3s (TBT 0, CLS 0 — fine), driven by:
1. **Main CSS bundle: 323 KiB raw, 89% unused** — full Bootstrap 5.3.8 compiled in
2. **"Enable text compression" penalty (~2050ms)** — CI serves the test site with `npx http-server` (no gzip), unlike Vercel production (brotli)

## Changes
- **`assets/scss/adritian.scss`**: full `bootstrap/bootstrap` import → selective module imports, audited against classes actually used in `layouts/` (grid, utilities API, nav/navbar/dropdown/card/breadcrumb/progress/pagination/alert/badge, forms subset, transitions, position/stretched-link/visually-hidden helpers)
- **`test-module-init.yml`**: `http-server --gzip` so CI Lighthouse measures compressed transfer like production

## Theme-safety constraint
**No PurgeCSS against site content** — the theme ships as a Hugo module to downstream sites with their own content/classes. Trimming is Bootstrap *module-level* only; the full utilities API (`d-*`, `m-*`, `p-*`, flex, text…) stays intact. A comment in the SCSS documents the convention for future additions.

## Results (measured locally, hugo v0.164.0)
- Main CSS: **323 → 241 KiB raw (−25%)**, **47.9 → 37.3 KiB gzipped (−22%)**
- Class-survival audit: `fixed-top`, `breadcrumb`, `progress-bar`, `alert`, `badge`, `pagination`, `dropdown-menu`, `navbar-collapse`, `form-control`, `d-flex`, `btn-primary` all present in built CSS
- `npm run build` ✅ · `npm run test:scripts` ✅

The CI Lighthouse run on this PR will show the real score delta (gzip fix alone should recover most of the compression penalty; CSS cut reduces transfer further).

## Deliberately deferred
- Vendored `bootstrap.bundle.min.js` (78 KiB, 64 KiB unused) — only Collapse + Dropdown are used; a custom js.Build bundle is a separate, riskier PR
- Responsive image sizes on the showcase webp (67 KiB potential)

🤖 Prepared by @zetxek via an AI coding agent (Claude Code), orchestrated + verified by Codebot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enabled gzip compression when serving the built site for performance evaluations.
  * Reduced unnecessary styling payload by selectively loading the required interface components and utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->