### PR TITLE
fix(i18n): add missing homepage section keys to es and fr locales

### DIFF
--- a/i18n/es.yaml
+++ b/i18n/es.yaml
@@ -34,6 +34,44 @@
 ## Homepage head title
 "head_title": ""
 "head_description": ""
+## Homepage showcase
+"showcase_title": ""
+"showcase_subtitle": ""
+"showcase_description": ""
+"showcase_button": "Contacto"
+## Homepage about
+"about_title": "¿Quién soy?"
+"about_content": ""
+"about_button": "Sobre mí"
+## Homepage education
+"education_title": "Educación"
+## Homepage experience
+"experience_button": "LinkedIn"
+"experience_button_url": ""
+"experience_button2": "Descargar currículum"
+"experience_button2_url": ""
+"experience_button3": "Ver todo"
+"experience_button3_url": "/experience"
+## Homepage client & work
+"client_work_title": "Clientes y trabajo"
+## Homepage newsletter
+"newsletter_title": "Newsletter"
+"newsletter_button": "Suscribirse"
+"newsletter_placeholder": "Tu correo electrónico"
+"newsletter_success_message": "¡Gracias por suscribirte a mi newsletter!"
+"newsletter_error_message": "Se produjo un error. Inténtalo de nuevo."
+"newsletter_note": "Nunca compartiremos tu email con nadie más."
+## Homepage testimonials
+"testimonials_title": "Testimonios"
+## Homepage contact
+"contact_title": "Contacto"
+"contact_button": "Enviar mensaje"
+"contact_form_name": "Nombre completo"
+"contact_form_email": "Dirección de correo electrónico"
+"contact_form_message": "Escribe tu mensaje aquí"
+"contact_phone_title": "Número de teléfono"
+"contact_email_title": "Correo electrónico"
+"contact_address_title": "Dirección"
 ## Blog
 "read_more": "Leer más"
 "published_on": "Publicado el "

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -34,6 +34,44 @@
 ## Homepage head title
 "head_title": ""
 "head_description": ""
+## Homepage showcase
+"showcase_title": ""
+"showcase_subtitle": ""
+"showcase_description": ""
+"showcase_button": "Contact"
+## Homepage about
+"about_title": "Qui suis-je ?"
+"about_content": ""
+"about_button": "À propos de moi"
+## Homepage education
+"education_title": "Formation"
+## Homepage experience
+"experience_button": "LinkedIn"
+"experience_button_url": ""
+"experience_button2": "Télécharger le CV"
+"experience_button2_url": ""
+"experience_button3": "Voir tout"
+"experience_button3_url": "/experience"
+## Homepage client & work
+"client_work_title": "Clients et projets"
+## Homepage newsletter
+"newsletter_title": "Newsletter"
+"newsletter_button": "S'abonner"
+"newsletter_placeholder": "Votre email"
+"newsletter_success_message": "Merci de vous être abonné à ma newsletter !"
+"newsletter_error_message": "Une erreur s'est produite. Veuillez réessayer."
+"newsletter_note": "Nous ne partagerons jamais votre email avec qui que ce soit."
+## Homepage testimonials
+"testimonials_title": "Témoignages"
+## Homepage contact
+"contact_title": "Contact"
+"contact_button": "Envoyer le message"
+"contact_form_name": "Nom complet"
+"contact_form_email": "Adresse email"
+"contact_form_message": "Saisissez votre message ici"
+"contact_phone_title": "Numéro de téléphone"
+"contact_email_title": "Email"
+"contact_address_title": "Adresse"
 ## Blog
 "read_more": "Lire la suite"
 "published_on": "Publié le "


### PR DESCRIPTION
## What

`i18n/es.yaml` and `i18n/fr.yaml` were each missing **30 homepage-section keys** that all 12 other locales (`en`, `de`, `ar`, `da`, `he`, `it`, `ko`, `nl`, `no`, `pl`, `pt`, `sv`) already had: the entire Showcase, About, Education, Experience buttons, Client & Work, Newsletter, Testimonials, and Contact blocks.

## Why

Hugo silently falls back to the default content language for missing i18n keys — so a Spanish or French site built with this theme rendered **English text for most of the homepage** while everything else (search, footer, blog, taxonomy) was correctly localized. The exampleSite ships a live `es` language config, so the gap was visible in the demo too. This looks like an oversight from the recent i18n modernization pass (`075eb6a`).

## Changes

- `i18n/es.yaml`: +38 lines (30 keys + section comments), keeping the file's existing informal *tú* register
- `i18n/fr.yaml`: +38 lines (30 keys + section comments), keeping the file's existing formal *vous* register
- Keys placed in the same order/section grouping as `en.yaml`; keys that are empty strings in `en.yaml` (e.g. `showcase_title`, `about_content`) are kept empty

No template or logic changes — translation-only.

## Verification

- ✅ Key parity: sorted key diff of `es.yaml`/`fr.yaml` vs `en.yaml` → zero missing (102 keys each)
- ✅ `tests/scripts/i18n-format.test.js` passes
- ✅ `exampleSite` builds clean with Hugo v0.164.0+extended (`hugo --gc --minify`)

## Review notes

- Native-speaker sanity check of the ES/FR phrasing is the main thing to eyeball (e.g. `experience_button2`: "Descargar currículum" / "Télécharger le CV")
- Confirming the empty-string choices match how `en.yaml` uses them is the other

---

🤖 Prepared by @zetxek via an AI coding agent (Claude Code, headless). All builds/tests verified locally before pushing.
